### PR TITLE
Replace defines of A,C,G,T,U, which caused compilation to fail

### DIFF
--- a/simfold/include/constants.h
+++ b/simfold/include/constants.h
@@ -95,11 +95,7 @@
 
 #define NUM_DANG       48        // there are 48 dangling ends 
 
-#define A               0
-#define C               1
-#define G               2
-#define U               3
-#define T               3
+enum bases {A,C,G,T,U=3};
 
 #define INF             1600000      // a very big value (infinity)
 #define NUCL            4            // number of nucleotides: 4: A, C, G, T


### PR DESCRIPTION
Hi @IanWark ,
I fixed a problem in the code, which caused my compiler to fail. Since constants.h redefines T, this interferes with template declarations. I am actually surprised that this failed only after including <memory> 

Probably it would be good to get rid of all or at least most of the define statements, but this change fixed the problem already.