### PR TITLE
Implement mode for dangling ends resembling ViennaRNA's -d2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(CCJ)
 
-
-# ==============================
-# DANGLE MODE
-# Sebastian Will, Sep 7, 2017
-# control energy contribution of dangles;
-# the mode number models Vienna RNA's -d option
-#
-# NOTE: this feature is not completely implemented; set to 1 to get
-# consistent behavior like in original simfold/CCJ
-add_definitions("-DDANGLE_MODE=2")
-
-
 # set SIMFOLD_HOME to simfold folder so CCJ binary can find it
 set(SIMFOLD_HOME ${CMAKE_SOURCE_DIR}/simfold)
 add_subdirectory(simfold)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,18 @@
 cmake_minimum_required(VERSION 3.1)
 project(CCJ)
 
+
+# ==============================
+# DANGLE MODE
+# Sebastian Will, Sep 7, 2017
+# control energy contribution of dangles;
+# the mode number models Vienna RNA's -d option
+#
+# NOTE: this feature is not completely implemented; set to 1 to get
+# consistent behavior like in original simfold/CCJ
+add_definitions("-DDANGLE_MODE=2")
+
+
 # set SIMFOLD_HOME to simfold folder so CCJ binary can find it
 set(SIMFOLD_HOME ${CMAKE_SOURCE_DIR}/simfold)
 add_subdirectory(simfold)

--- a/Sparse_CCJ/CCJ.cpp
+++ b/Sparse_CCJ/CCJ.cpp
@@ -50,9 +50,13 @@ int main (int argc, char *argv[])
                 if (!strcmp(arg, "-ngc"))
                     cmd_line_options.set_use_garbage_collection(false);
                 else
-                //
+                //  -d2 or -dangle2 to handle dangling ends like ViennaRNA's -d2 option
                 if (!strcmp(arg,"-d2") || !strcmp(arg,"-dangle2"))
                     DANGLE_MODE = 2;
+                else
+                // -vh to handle hairpins more similarily to ViennaRNA
+                if (!strcmp(arg,"-vh"))
+                    VIENNA_HAIRPIN = 2;
                 else
                 // -w special simple printing option
                 if (!strcmp(arg, "-w"))
@@ -83,7 +87,8 @@ int main (int argc, char *argv[])
     if (cmd_line_error) {
         printf ("Usage: %s <sequence> <arguments>\n", argv[0]);
         printf ("Valid arguments include: \n");
-        printf ("-d2 or -dangle2 to handle dangling ends like ViennaRNAs -d2 option\n");
+        printf ("-d2 or -dangle2 to handle dangling ends like ViennaRNA's -d2 option\n");
+        printf ("-vh to handle hairpins more similarily to ViennaRNA\n");
         printf ("-ns to use non-sparse or \"Modifed CCJ\" version\n");
         printf ("-ngc to not use garbage collection \n \n");
 

--- a/Sparse_CCJ/CCJ.cpp
+++ b/Sparse_CCJ/CCJ.cpp
@@ -46,13 +46,15 @@ int main (int argc, char *argv[])
                 if (!strcmp(arg, "-ns"))
                     cmd_line_options.set_use_sparse(false);
                 else
+		//  -d2 or -dangle2 to handle dangling ends like ViennaRNA's -d2 option
+                if (!strcmp(arg,"-d2") || !strcmp(arg,"-dangle2"))
+                    DANGLE_MODE = 2;
+                else	
+			
+		// ** The following arguments are primarily debug options **
                 // -ngc Do not use garbage collection
                 if (!strcmp(arg, "-ngc"))
                     cmd_line_options.set_use_garbage_collection(false);
-                else
-                //  -d2 or -dangle2 to handle dangling ends like ViennaRNA's -d2 option
-                if (!strcmp(arg,"-d2") || !strcmp(arg,"-dangle2"))
-                    DANGLE_MODE = 2;
                 else
                 // -w special simple printing option
                 if (!strcmp(arg, "-w"))

--- a/Sparse_CCJ/CCJ.cpp
+++ b/Sparse_CCJ/CCJ.cpp
@@ -54,10 +54,6 @@ int main (int argc, char *argv[])
                 if (!strcmp(arg,"-d2") || !strcmp(arg,"-dangle2"))
                     DANGLE_MODE = 2;
                 else
-                // -vh to handle hairpins more similarily to ViennaRNA
-                if (!strcmp(arg,"-vh"))
-                    VIENNA_HAIRPIN = 2;
-                else
                 // -w special simple printing option
                 if (!strcmp(arg, "-w"))
                     w = true;

--- a/Sparse_CCJ/CCJ.cpp
+++ b/Sparse_CCJ/CCJ.cpp
@@ -42,24 +42,35 @@ int main (int argc, char *argv[])
             for (int i = 2; i < argc; ++i) {
                 char * arg = argv[i];
 
+                // -ns Do not use sparse ("modified CCJ")
                 if (!strcmp(arg, "-ns"))
                     cmd_line_options.set_use_sparse(false);
                 else
+                // -ngc Do not use garbage collection
                 if (!strcmp(arg, "-ngc"))
                     cmd_line_options.set_use_garbage_collection(false);
                 else
+                //
+                if (!strcmp(arg,"-d2") || !strcmp(arg,"-dangle2"))
+                    DANGLE_MODE = 2;
+                else
+                // -w special simple printing option
                 if (!strcmp(arg, "-w"))
                     w = true;
                 else
+                // -pta to print information on the number of trace arrows
                 if (!strcmp(arg, "-pta"))
                     cmd_line_options.set_print_trace_arrow_info(1);
                 else
+                // -pta-v to print verbose trace arrow information
                 if (!strcmp(arg, "-pta-v"))
                     cmd_line_options.set_print_trace_arrow_info(2);
                 else
+                // -pcl to print information on the candidate lists
                 if (!strcmp(arg, "-pcl"))
                     cmd_line_options.set_print_candidate_list_info(1);
                 else
+                // -pcl-v to print verbose candidate list information
                 if (!strcmp(arg, "-pcl-v"))
                     cmd_line_options.set_print_candidate_list_info(2);
                 else
@@ -72,6 +83,7 @@ int main (int argc, char *argv[])
     if (cmd_line_error) {
         printf ("Usage: %s <sequence> <arguments>\n", argv[0]);
         printf ("Valid arguments include: \n");
+        printf ("-d2 or -dangle2 to handle dangling ends like ViennaRNAs -d2 option\n");
         printf ("-ns to use non-sparse or \"Modifed CCJ\" version\n");
         printf ("-ngc to not use garbage collection \n \n");
 

--- a/Sparse_CCJ/README.md
+++ b/Sparse_CCJ/README.md
@@ -22,9 +22,8 @@ Run from a command line in Sparse_CCJ directory:
 ```
 where \<sequence> is the input RNA sequence and \<arguments> are detailed below.
 
-Valid agruments include:   
+Valid arguments include:   
 -d2 or -dangle2 to handle dangling ends like ViennaRNA's -d2 option   
--vh to handle hairpins more similarily to ViennaRNA   
 -ns to use non-sparse or "Modifed CCJ" version  
 -ngc to not use garbage collection for Sparse CCJ   
 

--- a/Sparse_CCJ/README.md
+++ b/Sparse_CCJ/README.md
@@ -23,8 +23,10 @@ Run from a command line in Sparse_CCJ directory:
 where \<sequence> is the input RNA sequence and \<arguments> are detailed below.
 
 Valid agruments include:   
+-d2 or -dangle2 to handle dangling ends like ViennaRNA's -d2 option   
+-vh to handle hairpins more similarily to ViennaRNA   
 -ns to use non-sparse or "Modifed CCJ" version  
--ngc to not use garbage collection for Sparse CCJ
+-ngc to not use garbage collection for Sparse CCJ   
 
 -shape="filename" to specify a file for shape data   
 -b=number to specify an intercept for the shape data (default is -0.600000)   

--- a/Sparse_CCJ/VM_final.cpp
+++ b/Sparse_CCJ/VM_final.cpp
@@ -36,6 +36,8 @@ VM_final::~VM_final()
     delete [] VM;
 }
 
+/*
+SW Sep 15, 2017 -- this code is NOT USED
 void VM_final::compute_energy(int i, int j){
 
 	// here comes the copied part from simfold with all dangling energies
@@ -54,8 +56,24 @@ void VM_final::compute_energy(int i, int j){
 
 
         tmp = WM[iplus1k] + WM[kplus1jminus1];
+
+        if (DANGLE_MODE==2) {
+            int de =
+                dangle_top [sequence [i]][sequence [j]][sequence [i+1]] + dangle_bot [sequence[i]][sequence[j]][sequence[j-1]];
+
+            std::cout << "Add dangling for ML closing bp "
+                      << de
+                      << std::endl;
+
+            tmp += de;
+        }
+
         if (tmp < min_energy)
             min_energy = tmp;
+
+        if (DANGLE_MODE != 1) {
+            continue;
+        }
 
 		tmp = WM[iplus2k] + WM[kplus1jminus1] +dangle_top [sequence [i]][sequence [j]][sequence [i+1]] + misc.multi_free_base_penalty;
 		
@@ -107,6 +125,7 @@ void VM_final::compute_energy(int i, int j){
 		printf ("VM(%d,%d) energy %d\n", i, j, VM[ij]);
 
 }
+*/
 
 int VM_final::get_energy(int i, int j){
 	int ij = index[i]+j-i;

--- a/Sparse_CCJ/VM_final.h
+++ b/Sparse_CCJ/VM_final.h
@@ -22,7 +22,8 @@ public:
 		this->p = P;
 	}
 	void set_VM_matrix(s_multi_loop *vm){s_vm = vm;}
-	void compute_energy(int i, int j);
+	// void compute_energy(int i, int j); // SW Sep 15, 2017 -- this method is NOT USED
+
 	int get_energy(int i, int j);
 	void WM_compute_energy(int i, int j);
 	void set_WM_matrix(int *m){this->WM = m;}

--- a/Sparse_CCJ/W_final.h
+++ b/Sparse_CCJ/W_final.h
@@ -54,8 +54,10 @@ class W_final: public s_min_folding{
 
 
         int compute_W_br2 (int j);
+        // reduce W to V
 
 		int compute_W_br3 (int j);
+        // reduce W to P
 
         void print_result();
         // PRE:  The matrix V has been calculated and the results written in f
@@ -65,7 +67,10 @@ class W_final: public s_min_folding{
 	// Hosna Feb 18, 2014
 	// This function goes over the f array and fills the structure knowing which base pairs with which
 
-
+        int outer_dangles(int i, int j);
+        // Sebastian, Sep 7, 2017:
+        // energy contributions of left and right dangling end of stem closed by i and j;
+        // use for d2 mode
 
 };
 

--- a/Sparse_CCJ/trace_arrow.cpp
+++ b/Sparse_CCJ/trace_arrow.cpp
@@ -7,7 +7,8 @@ ta_key_pair::ta_key_pair(index_t k, index_t l) {
     second = l;
     value_ = first*ta_n - second;
 
-    assert(value_ > 0 && value_ < 65535);
+    // ensure value does not overflow
+    assert(value_ > 0 && value_ < 4294967295);
 }
 
 TraceArrows::TraceArrows(size_t n, char srctype)
@@ -238,7 +239,7 @@ MasterTraceArrows::gc_row( size_t i, TraceArrows &source ) {
 
         // Call garbage collection on all the trace arrows at ij
         while (it != source.trace_arrow_[ij].end()) {
-    
+
             // gc_trace_arrow returns true on successful deletion of a trace arrow, else false
             // If gc_trace_arrow erased that trace arrow go back one before continuing
             if(gc_trace_arrow(i,j,it,source)) {
@@ -266,8 +267,8 @@ MasterTraceArrows::gc_row( size_t i, TraceArrows &source ) {
 }
 
 /** @brief Garbage collection of a trace arrow (TA)
- *  If TA's source_ref_count == 0, deletes it 
- *  and calls gc_to_target on what TA it is pointing at 
+ *  If TA's source_ref_count == 0, deletes it
+ *  and calls gc_to_target on what TA it is pointing at
  *  (to change target TA's source_ref_count and possibly delete that TA as well).
  *  Called primarily by gc_row and gc_to_target
  *  @return true if that trace arrow was erased, else false

--- a/simfold/include/constants.h
+++ b/simfold/include/constants.h
@@ -20,14 +20,14 @@
 
 // define the model
 
-// Instead of doing this, I have 3 levels of parsi_xxx variables. 
+// Instead of doing this, I have 3 levels of parsi_xxx variables.
 //  This permits me to add things on top of the SIMPLE (turner99) model, and also to compile only once
 #define PARSI 1
 #define LAVISH 0
 #define T99 2
-#define ZL 3 
+#define ZL 3
 // ZL is the Zhiang_Liang_2008 model for bulge and internal loop length. The number of features is the same as for parsimonious. I only incorporate the slope.
-#define HLI 4   
+#define HLI 4
 // HLI = HALF LAVISH for internal loops: meaning I add the parsi, + the internal loops that appear in the experiments, but no more.
 // the implementation for HLI is not finished
 #define T99_LAVISH  5
@@ -38,7 +38,7 @@
 // #else
 // #define MODEL SIMPLE
 // #endif
-// 
+//
 // #define SIMPLE 0        // the model with 363 parameters that I used in the ISMB 2007 paper
 // #define EXTENDED 1
 
@@ -93,7 +93,7 @@
 // for MultiFold
 #define MAXNUMSEQ      50
 
-#define NUM_DANG       48        // there are 48 dangling ends 
+#define NUM_DANG       48        // there are 48 dangling ends
 
 enum bases {A,C,G,T,U=3};
 
@@ -102,10 +102,10 @@ enum bases {A,C,G,T,U=3};
 #define MAXLOOP         30           // max size for internal loops, hairpin loops and bulge loops
 
 #define MAXLOOP_ASYM    29
-#define MAX_EXP_ASYM    4           
+#define MAX_EXP_ASYM    4
 // the maximum internal loop asymmetry (abs(size1-size2)) for which we have experimental values
 
-// max loop size for which tabulated values are experimentally determined 
+// max loop size for which tabulated values are experimentally determined
 //    for len > MAX, the following formula is applied: lenpen (len) = lenpen(MAX) + 1.75 RT*log(1.0*len/MAX));
 //    RT = 1.75 * 1.98717 / 1000 * 310.15;
 
@@ -118,8 +118,8 @@ enum bases {A,C,G,T,U=3};
 #define MAXLOOP_I_PARSI   10
 #define MAXLOOP_B_PARSI   3
 
-#define MAXLOOP_H_LAVISH     30 
-#define MAXLOOP_I_LAVISH     30 
+#define MAXLOOP_H_LAVISH     30
+#define MAXLOOP_I_LAVISH     30
 #define MAXLOOP_B_LAVISH     30
 
 #define MAXTRILOOPNO    100          // max number of hairpin loops of size 3
@@ -146,7 +146,7 @@ enum bases {A,C,G,T,U=3};
 #define FREE            'W'         // this base is free to be paired or unpaired to other base
 #define LOOP            'V'         // closes a loop
 
-#define M_FM            'F'         // regular FM from the multiloop decomposition of Wutchy et al 
+#define M_FM            'F'         // regular FM from the multiloop decomposition of Wutchy et al
 #define M_FM1           'A'         // regular FM1 from the multiloop decomposition of Wutchy et al
 
 #define M_FM_LINK       'P'         // special FM adapted from FM = the multiloop decomposition of Wutchy et al

--- a/simfold/include/externs.h
+++ b/simfold/include/externs.h
@@ -16,10 +16,10 @@
  ***************************************************************************/
 
 // this file contains the "extern" version of the global variables. It's the mirror of globals.h.
-// Include globals.h in the driver, and externs.h in the library files. If you include globals.h 
+// Include globals.h in the driver, and externs.h in the library files. If you include globals.h
 // twice, you get linking errors.
- 
- 
+
+
 #ifndef EXTERNS_H
 #define EXTERNS_H
 
@@ -30,6 +30,7 @@
 // mode number models Vienna RNA's -d option
 // 1 is normal, original CCJ. 2 is used for compatibility with Vienna RNA
 extern int DANGLE_MODE;
+extern int VIENNA_HAIRPIN;
 
 extern int *known_pairings;    // used for the loss-augmented prediction
 extern int *pred_pairings;
@@ -62,7 +63,7 @@ extern int creating_model;
 
 //#if (MODEL == EXTENDED)
 extern int start_bulge;
-extern int start_internal;    
+extern int start_internal;
 extern int start_internal11;
 extern int start_internal11_C;
 extern int start_internal11_G;
@@ -73,10 +74,10 @@ extern int start_internal21_AUA;   // first, second and third
 extern int start_internal21_AUC;
 extern int start_internal21_AUG;
 extern int start_internal21_AUU;
-extern int start_internal21_CGA;  
-extern int start_internal21_CGC;  
-extern int start_internal21_CGG;  
-extern int start_internal21_CGU;  
+extern int start_internal21_CGA;
+extern int start_internal21_CGC;
+extern int start_internal21_CGG;
+extern int start_internal21_CGU;
 extern int start_internal21_GCA;
 extern int start_internal21_GCC;
 extern int start_internal21_GCG;
@@ -125,14 +126,14 @@ extern int start_internal_size;
 extern int start_bulge_size;
 extern int start_hairpin_size;
 extern int start_misc_last;       // the last misc: from misc.terminal_AU_penalty on
-extern int start_special_hl; 
+extern int start_special_hl;
 //#endif
 
 
 extern char similarity_rule[MAXNUMPARAMS][2000];
 
 extern char string_params[MAXNUMPARAMS][MAXPNAME];    // for playing with the parameters
-extern char string_params_human_readable[MAXNUMPARAMS][MAXPNAME]; 
+extern char string_params_human_readable[MAXNUMPARAMS][MAXPNAME];
 extern int num_params;
 
 extern char bbseq_left[MAXNUMPARAMS][10];   // the 5' sequence of the corresponding building block
@@ -142,7 +143,7 @@ extern char bbstr_right[MAXNUMPARAMS][10];   // the 3' structure of the correspo
 
 // this is used for parameter learning only
 extern int counter_min_dangle[NUM_DANG][NUM_DANG];                    // cell[0][1] says how many times min(dangle0,dangle1) appear, where dangle0 is x213 in the 318 nomenclature
-// there are 48 dangling ends: 24 top and 24 bottom. 
+// there are 48 dangling ends: 24 top and 24 bottom.
 
 
 extern PARAMTYPE stack [NUCL] [NUCL] [NUCL] [NUCL];
@@ -169,7 +170,7 @@ extern hairpin_tloop special_hl[MAX_SPECIAL_LOOP_NO];
 extern int nb_special_hl;
 
 // middle of asymmetric internal loops 2x2
-//extern PARAMTYPE int22mid[NUCL] [NUCL] [NUCL] [NUCL]; 
+//extern PARAMTYPE int22mid[NUCL] [NUCL] [NUCL] [NUCL];
 
 extern PARAMTYPE int11_experimental_addition   [NUCL] [NUCL] [NUCL] [NUCL] [NUCL] [NUCL];       // values to be added to the simple 10-parameter model proposed by Davis_Znosko_2007, so that we use the experimental values for these parameters
 extern PARAMTYPE int21_experimental_addition   [NUCL] [NUCL] [NUCL] [NUCL] [NUCL] [NUCL] [NUCL];       // values to be added to the simple 6-parameter model proposed by Badhwar_Znosko_2007, so that we use the experimental values for these parameters

--- a/simfold/include/externs.h
+++ b/simfold/include/externs.h
@@ -30,7 +30,6 @@
 // mode number models Vienna RNA's -d option
 // 1 is normal, original CCJ. 2 is used for compatibility with Vienna RNA
 extern int DANGLE_MODE;
-extern int VIENNA_HAIRPIN;
 
 extern int *known_pairings;    // used for the loss-augmented prediction
 extern int *pred_pairings;

--- a/simfold/include/externs.h
+++ b/simfold/include/externs.h
@@ -26,6 +26,11 @@
 #include "structs.h"
 #include "constants.h"
 
+// global for which dangle mode to use
+// mode number models Vienna RNA's -d option
+// 1 is normal, original CCJ. 2 is used for compatibility with Vienna RNA
+extern int DANGLE_MODE;
+
 extern int *known_pairings;    // used for the loss-augmented prediction
 extern int *pred_pairings;
 

--- a/simfold/include/globals.h
+++ b/simfold/include/globals.h
@@ -33,6 +33,11 @@ int max_internal_loop = MAXLOOP;
 int *constraints;
 int fix_dangles = 0;
 
+// global for which dangle mode to use
+// mode number models Vienna RNA's -d option
+// 1 is normal, original CCJ. 2 is used for compatibility with Vienna RNA
+int DANGLE_MODE = 1;
+
 int *known_pairings = NULL;    // used for the loss-augmented prediction
 int *pred_pairings = NULL;
 

--- a/simfold/include/globals.h
+++ b/simfold/include/globals.h
@@ -16,9 +16,9 @@
  ***************************************************************************/
 
 // this file contains mainly the global variables. It's the mirror of externs.h.
-// Include globals.h in the driver, and externs.h in the library files. If you include globals.h 
-// twice, you get linking errors. 
- 
+// Include globals.h in the driver, and externs.h in the library files. If you include globals.h
+// twice, you get linking errors.
+
 #ifndef GLOBALS_H
 #define GLOBALS_H
 
@@ -37,6 +37,7 @@ int fix_dangles = 0;
 // mode number models Vienna RNA's -d option
 // 1 is normal, original CCJ. 2 is used for compatibility with Vienna RNA
 int DANGLE_MODE = 1;
+int VIENNA_HAIRPIN = 0;
 
 int *known_pairings = NULL;    // used for the loss-augmented prediction
 int *pred_pairings = NULL;
@@ -45,18 +46,18 @@ char similarity_rule[MAXNUMPARAMS][5000];
 
 // these variables are used for all models: turner99, parsimonious and lavish
 //  For each of the variables, LAVISH (0) means lavish, PARSI (1) means parsimonious, T99 (2) means turner99 (sometimes they overlap)
-// In addition, I incorporated the Zhang_Liang_2008 model for bulge loop and internal loop length. 
+// In addition, I incorporated the Zhang_Liang_2008 model for bulge loop and internal loop length.
 //      In this case, parsi_length is ZL (3). The only modifications are in params.cpp:extrapolate_parameters.
-// For parsi_special, for now, by default it's only the new ones. To add the old tetraloops, do this: 
+// For parsi_special, for now, by default it's only the new ones. To add the old tetraloops, do this:
 //  cp params/turner-special-hairpins-rna.dat params/turner-special-hairpins-rna-only-new.dat
 //  cp params/turner-special-hairpins-rna-with-T99.dat params/turner-special-hairpins-rna.dat
 int parsi_tstackh = T99;   // 0: lavish and turner99 model for tstackh; 1: parsimonious model
-int parsi_tstacki = T99;   
+int parsi_tstacki = T99;
 int parsi_asymmetry = T99;    // category 3
 int parsi_int11 = T99;      // category 4
 int parsi_int21 = T99;      // category 5
 int parsi_int22 = T99;      // category 6
-int parsi_bulge1 = T99;    // 0: lavish for bulge1; 1: parsi for bulge1, i.e. 4 features; 2: turner99, i.e. no bulge features  
+int parsi_bulge1 = T99;    // 0: lavish for bulge1; 1: parsi for bulge1, i.e. 4 features; 2: turner99, i.e. no bulge features
 int parsi_dangles = T99;      // category 8
 int parsi_length = T99;      // category L
 int parsi_special = T99;      // category S
@@ -67,7 +68,7 @@ int creating_model = 0;     // this is 1 only when I use the thermo xml set to f
 
 //#if (MODEL == EXTENDED)   // I'm not using SIMPLE and EXTENDED model any more
 int start_bulge = 21;
-int start_internal = 25;    
+int start_internal = 25;
 int start_internal11 = 25;
 int start_internal11_C = 25;    //130;
 int start_internal11_G = 25;    //204;
@@ -78,10 +79,10 @@ int start_internal21_AUA = 40;      //46;   // first, second and third
 int start_internal21_AUC = 40;      //142;
 int start_internal21_AUG = 40;      //238;
 int start_internal21_AUU = 40;      //334;
-int start_internal21_CGA = 40;      //430;  
-int start_internal21_CGC = 40;      //526;  
-int start_internal21_CGG = 40;      //622;  
-int start_internal21_CGU = 40;      //718;  
+int start_internal21_CGA = 40;      //430;
+int start_internal21_CGC = 40;      //526;
+int start_internal21_CGG = 40;      //622;
+int start_internal21_CGU = 40;      //718;
 int start_internal21_GCA = 40;      //814;
 int start_internal21_GCC = 40;      //910;
 int start_internal21_GCG = 40;      //1006;
@@ -130,7 +131,7 @@ int start_internal_size = 52;
 int start_bulge_size = 61;
 int start_hairpin_size = 63;
 int start_misc_last = 70;       // the last misc: from misc.terminal_AU_penalty on
-int start_special_hl = 75; 
+int start_special_hl = 75;
 
 
 // energies information
@@ -200,39 +201,39 @@ int nb_params = 58;
 char par_name [58] [100] = {
             "STD_DIR",
             "RNA_STACK_ENERGY37_V31",
-            "RNA_STACK_ENERGY37_V23",            
-            "RNA_STACK_ENTHALPY",            
+            "RNA_STACK_ENERGY37_V23",
+            "RNA_STACK_ENTHALPY",
             "RNA_LOOP_ENERGY37_V31",
-            "RNA_LOOP_ENERGY37_V23",            
-            "RNA_LOOP_ENTHALPY",            
+            "RNA_LOOP_ENERGY37_V23",
+            "RNA_LOOP_ENTHALPY",
             "RNA_TRILOOP_ENERGY37_V31",
-            "RNA_TRILOOP_ENERGY37_V23",            
-            "RNA_TRILOOP_ENTHALPY",                        
+            "RNA_TRILOOP_ENERGY37_V23",
+            "RNA_TRILOOP_ENTHALPY",
             "RNA_TLOOP_ENERGY37_V31",
-            "RNA_TLOOP_ENERGY37_V23",            
-            "RNA_TLOOP_ENTHALPY",                        
+            "RNA_TLOOP_ENERGY37_V23",
+            "RNA_TLOOP_ENTHALPY",
             "RNA_TSTACKH_ENERGY37_V31",
-            "RNA_TSTACKH_ENERGY37_V23",            
-            "RNA_TSTACKH_ENTHALPY",            
+            "RNA_TSTACKH_ENERGY37_V23",
+            "RNA_TSTACKH_ENTHALPY",
             "RNA_TSTACKI_ENERGY37_V31",
-            "RNA_TSTACKI_ENERGY37_V23",            
-            "RNA_TSTACKI_ENTHALPY",            
+            "RNA_TSTACKI_ENERGY37_V23",
+            "RNA_TSTACKI_ENTHALPY",
             "RNA_INT11_ENERGY37_V31",
-            "RNA_INT11_ENERGY37_V23",            
-            "RNA_INT11_ENTHALPY",            
+            "RNA_INT11_ENERGY37_V23",
+            "RNA_INT11_ENTHALPY",
             "RNA_INT21_ENERGY37_V31",
-            "RNA_INT21_ENERGY37_V23",            
-            "RNA_INT21_ENTHALPY",            
+            "RNA_INT21_ENERGY37_V23",
+            "RNA_INT21_ENTHALPY",
             "RNA_INT22_ENERGY37_V31",
-            "RNA_INT22_ENERGY37_V23",            
-            "RNA_INT22_ENTHALPY",            
+            "RNA_INT22_ENERGY37_V23",
+            "RNA_INT22_ENTHALPY",
             "RNA_MISCLOOP_ENERGY37_V31",
-            "RNA_MISCLOOP_ENERGY37_V23",            
-            "RNA_MISCLOOP_ENTHALPY",            
+            "RNA_MISCLOOP_ENERGY37_V23",
+            "RNA_MISCLOOP_ENTHALPY",
             "RNA_DANGLE_ENERGY37_V31",
-            "RNA_DANGLE_ENERGY37_V23",            
+            "RNA_DANGLE_ENERGY37_V23",
             "RNA_DANGLE_ENTHALPY",
-            
+
             "DNA_STACK_ENERGY37",
             "DNA_STACK_ENTHALPY",
             "DNA_LOOP_ENERGY37",
@@ -342,7 +343,7 @@ char bbstr_left[MAXNUMPARAMS][10];   // the 5' structure of the corresponding bu
 char bbstr_right[MAXNUMPARAMS][10];   // the 3' structure of the corresponding building block
 
 int counter_min_dangle[NUM_DANG][NUM_DANG];    // cell[0][1] says how many times min(dangle0,dangle1) appear, where dangle0 is x213 in the 318 nomenclature
-// there are 48 dangling ends: 24 top and 24 bottom. 
+// there are 48 dangling ends: 24 top and 24 bottom.
 
 
 

--- a/simfold/include/globals.h
+++ b/simfold/include/globals.h
@@ -37,7 +37,6 @@ int fix_dangles = 0;
 // mode number models Vienna RNA's -d option
 // 1 is normal, original CCJ. 2 is used for compatibility with Vienna RNA
 int DANGLE_MODE = 1;
-int VIENNA_HAIRPIN = 0;
 
 int *known_pairings = NULL;    // used for the loss-augmented prediction
 int *pred_pairings = NULL;

--- a/simfold/src/common/common.cpp
+++ b/simfold/src/common/common.cpp
@@ -730,11 +730,6 @@ size_penalties_class::size_penalties_class(int nb_nucleotides) {
             }
         }
 
-        if (VIENNA_HAIRPIN) {
-            // This is because right now ViennaRNA's equivalent is 30 and so is MAXLOOP_H_LAVISH
-            end = MAXLOOP_H_LAVISH;
-        }
-
         arr[type].resize(nb_nucleotides);
         // for each possible size (0..nb_nucleotides-1)
         for (int size=0; size < nb_nucleotides; size++) {

--- a/simfold/src/common/common.cpp
+++ b/simfold/src/common/common.cpp
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include <iostream>
 #include "constants.h"
 #include "structs.h"
 #include "externs.h"
@@ -154,7 +155,7 @@ int loss (int first, int last)
 // Written on August 9, 2008
 // Note: Maybe this measure is better than the Hamming distance:
 //      (# correctly predicted bp - # incorrectly predicted bp) / # true bp.
-//      This will be in (-inf,1], but it only includes the base pairs, 
+//      This will be in (-inf,1], but it only includes the base pairs,
 //      whereas the Hamming distance measure also includes the unpaired bases.
 {
     if (known_pairings == NULL) return 0;
@@ -181,9 +182,9 @@ double compute_accuracy (char *ref_structure, char *pred_structure)
     int distance;
     int len, i;
     double accuracy;
-    
+
     len = strlen(ref_structure);
-    detect_original_pairs (ref_structure, ptable_ref);    
+    detect_original_pairs (ref_structure, ptable_ref);
     detect_original_pairs (pred_structure, ptable_pred);
     distance = 0;
     for (i=0; i < len; i++)
@@ -191,7 +192,7 @@ double compute_accuracy (char *ref_structure, char *pred_structure)
         if (ptable_pred[i] != ptable_ref[i])
             distance ++;
     }
-    accuracy = 1.0-(double)distance/len; 
+    accuracy = 1.0-(double)distance/len;
     return accuracy;
 }
 
@@ -204,9 +205,9 @@ double compute_distance (char *ref_structure, char *pred_structure)
     int ptable_pred[MAXSLEN];
     int distance;
     int len, i;
-    
+
     len = strlen(ref_structure);
-    detect_original_pairs (ref_structure, ptable_ref);    
+    detect_original_pairs (ref_structure, ptable_ref);
     detect_original_pairs (pred_structure, ptable_pred);
     distance = 0;
     for (i=0; i < len; i++)
@@ -228,9 +229,9 @@ double compute_sensitivity (char *ref_structure, char *pred_structure)
     double sens;
     int num_correct_bp;
     int num_true_bp;
-        
+
     len = strlen(ref_structure);
-    detect_original_pairs (ref_structure, ptable_ref);    
+    detect_original_pairs (ref_structure, ptable_ref);
     detect_original_pairs (pred_structure, ptable_pred);
     num_correct_bp = 0;
     num_true_bp = 0;
@@ -241,7 +242,7 @@ double compute_sensitivity (char *ref_structure, char *pred_structure)
             num_true_bp++;
             if (ptable_pred[i] == ptable_ref[i])
                 num_correct_bp++;
-        }                
+        }
     }
     if (num_true_bp == 0)
         return 0.0;
@@ -260,9 +261,9 @@ double compute_ppv (char *ref_structure, char *pred_structure)
     double ppv;
     int num_correct_bp;
     int num_pred_bp;
-        
+
     len = strlen(ref_structure);
-    detect_original_pairs (ref_structure, ptable_ref);    
+    detect_original_pairs (ref_structure, ptable_ref);
     detect_original_pairs (pred_structure, ptable_pred);
     num_correct_bp = 0;
     num_pred_bp = 0;
@@ -271,7 +272,7 @@ double compute_ppv (char *ref_structure, char *pred_structure)
         if (ptable_ref[i] > -1 && ptable_pred[i] == ptable_ref[i])    // paired base
             num_correct_bp++;
         if (ptable_pred[i] > -1)    // paired base
-            num_pred_bp++;            
+            num_pred_bp++;
     }
     if (num_pred_bp == 0)
         return 0.0;
@@ -291,16 +292,16 @@ double compute_pf_ppv (char *ref_structure, s_partition_function *part, double t
     double ppv=0.0;
     int num_correct_bp;
     int num_pred_bp;
-        
+
     // prob begins from 1, and ptable_ref begins from 0
 
     len = strlen(ref_structure);
-    detect_original_pairs (ref_structure, ptable_ref);    
+    detect_original_pairs (ref_structure, ptable_ref);
 
     num_correct_bp = 0;
     num_pred_bp = 0;
-    
-    
+
+
     for (i=0; i < len; i++)
     {
         for (j=i+1; j < len; j++)
@@ -308,7 +309,7 @@ double compute_pf_ppv (char *ref_structure, s_partition_function *part, double t
             if (part->get_probability(i,j) >= threshold && ptable_ref[i] == j)
                 num_correct_bp++;
             if (part->get_probability(i,j) >= threshold)
-                num_pred_bp++;            
+                num_pred_bp++;
         }
     }
 
@@ -320,12 +321,12 @@ double compute_pf_ppv (char *ref_structure, s_partition_function *part, double t
         for (j=i+1; j < len; j++)
         {
             if (prob[i+1][j+1] >= threshold)
-                printf ("\tprob[%d][%d]=%.2lf\n", i+1, j+1, prob[i+1][j+1]); 
+                printf ("\tprob[%d][%d]=%.2lf\n", i+1, j+1, prob[i+1][j+1]);
         }
     }
     printf ("num_correct_bp=%d, num_pred_bp=%d\n", num_correct_bp, num_pred_bp);
     */
-    
+
     if (num_pred_bp == 0)
     {
         //printf ("Undefined ppv\n");
@@ -333,7 +334,7 @@ double compute_pf_ppv (char *ref_structure, s_partition_function *part, double t
         return 0.0;
     }
     ppv = num_correct_bp*1.0/num_pred_bp;
-    printf ("Thr=%.2lf, ppv=%.2lf, nu_corr=%d, num_pred=%d\n", threshold, ppv, num_correct_bp, num_pred_bp);        
+    printf ("Thr=%.2lf, ppv=%.2lf, nu_corr=%d, num_pred=%d\n", threshold, ppv, num_correct_bp, num_pred_bp);
     return ppv;
 }
 
@@ -349,9 +350,9 @@ double compute_pf_sensitivity (char *ref_structure, s_partition_function *part, 
     double sens=0.0;
     int num_correct_bp;
     int num_true_bp;
-        
+
     len = strlen(ref_structure);
-    detect_original_pairs (ref_structure, ptable_ref);    
+    detect_original_pairs (ref_structure, ptable_ref);
     num_correct_bp = 0;
     num_true_bp = 0;
 
@@ -363,7 +364,7 @@ double compute_pf_sensitivity (char *ref_structure, s_partition_function *part, 
         for (j=i+1; j < len; j++)
         {
             if (prob[i+1][j+1] >= threshold)
-                printf ("\tprob[%d][%d]=%.2lf\n", i+1, j+1, prob[i+1][j+1]); 
+                printf ("\tprob[%d][%d]=%.2lf\n", i+1, j+1, prob[i+1][j+1]);
         }
     }
     */
@@ -377,7 +378,7 @@ double compute_pf_sensitivity (char *ref_structure, s_partition_function *part, 
                 if (part->get_probability(i,j) >= threshold && ptable_ref[i] == j)
                     num_correct_bp++;
             }
-        }                
+        }
     }
     if (num_true_bp == 0)
     {
@@ -446,7 +447,7 @@ void create_random_restricted (char *sequence, char *restricted)
             restricted [MAX (rnumber1, rnumber2)] = ')';
             break;
         }
-    }    
+    }
 }
 
 
@@ -463,8 +464,8 @@ void remove_space (char *structure)
         if (structure[i] != ' ')
             str2[j++] = structure[i];
     }
-    str2[j] = '\0';    
-    strcpy (structure, str2);    
+    str2[j] = '\0';
+    strcpy (structure, str2);
 }
 
 
@@ -496,7 +497,7 @@ int can_pair (int base1, int base2)
             {
                 case G: return 1;
                 default: return 0;
-            }                        
+            }
         case G:
             switch (base2)
             {
@@ -508,8 +509,8 @@ int can_pair (int base1, int base2)
             {
                 case A: case G: return 1;
                 default: return 0;
-            }               
-    }  
+            }
+    }
 }
 
 
@@ -531,7 +532,7 @@ int watson_crick (int base1, int base2)
             {
                 case G: return 1;
                 default: return 0;
-            }                        
+            }
         case G:
             switch (base2)
             {
@@ -543,8 +544,8 @@ int watson_crick (int base1, int base2)
             {
                 case A: return 1;
                 default: return 0;
-            }               
-    }  
+            }
+    }
 }
 
 
@@ -609,7 +610,7 @@ char int_to_nuc (int inuc)
 
 
 int is_nucleotide (char base)
-// PRE:  base is a character 
+// PRE:  base is a character
 // POST: return true if base is a nucleotide (A, C, G or T)
 //     return false otherwise
 {
@@ -727,6 +728,11 @@ size_penalties_class::size_penalties_class(int nb_nucleotides) {
                     printf("Error in simfold/src/common/common.cpp creation of size_penalties\n");
                     exit(-1);
             }
+        }
+
+        if (VIENNA_HAIRPIN) {
+            // This is because right now ViennaRNA's equivalent is 30 and so is MAXLOOP_H_LAVISH
+            end = MAXLOOP_H_LAVISH;
         }
 
         arr[type].resize(nb_nucleotides);
@@ -882,7 +888,7 @@ void insert_space (char *structure, int place)
     //strncpy (structure, str, length+1);
     for (i = 0; i <= length; i++)
         structure[i] = str[i];
-    structure[i] = '\0';    
+    structure[i] = '\0';
     //strcpy (structure, str);
 }
 
@@ -932,7 +938,7 @@ void detect_original_pairs(char *structure, int *p_table)
         struct_len = strlen (structure);
         for (i=0; i < struct_len; i++)
           {
-            if (structure[i] == '.') 
+            if (structure[i] == '.')
               p_table[i] = -1;
             else if (structure[i] == ' ' || structure[i] == '_')
               p_table[i] = -2;
@@ -998,7 +1004,7 @@ void detect_structure_features (char *structure, str_features *f)
         if (p_table[i] > i)
         {
             f[p_table[i]].pair = i;
-            // this base pair might be angle brackets or parentheses.            
+            // this base pair might be angle brackets or parentheses.
             if (structure[i] == '<')
             {
                 // first make sure the pair is also angle bracket
@@ -1019,7 +1025,7 @@ void detect_structure_features (char *structure, str_features *f)
 //                         exit(1);
 //                     }
 //                 }
-                continue;                
+                continue;
             }
             // if we got here, it means the base pair was ()
             // just make sure the partner is )
@@ -1134,7 +1140,7 @@ int complementary_bases (char b1, char b2)
             {
                 case G: return 1;
                 default: return 0;
-            }                        
+            }
         case G:
             switch (base2)
             {
@@ -1146,8 +1152,8 @@ int complementary_bases (char b1, char b2)
             {
                 case A: return 1;
                 default: return 0;
-            }               
-    }      
+            }
+    }
 }
 
 int self_complementary (char *sequence)
@@ -1224,7 +1230,7 @@ void read_parsi_options_from_file (char *filename)
     fgets (buffer, sizeof(buffer), file);
     while (!feof (file))
     {
-        //printf ("buffer = %s\n", buffer);                
+        //printf ("buffer = %s\n", buffer);
         sscanf (buffer, "%s = %d", option, &value);
         //printf ("option = |%s|, value = |%d|\n", option, value);
         if (strcmp (option, "parsi_tstackh") == 0)          parsi_tstackh = value;
@@ -1240,7 +1246,7 @@ void read_parsi_options_from_file (char *filename)
         else if (strcmp (option, "parsi_special") == 0)     parsi_special = value;
         else if (strcmp (option, "use_similarity_rules") == 0)     use_similarity_rules = value;
         fgets (buffer, sizeof(buffer), file);
-    }    
+    }
     fclose (file);
 //     printf ( "parsi_tstackh = %d\n", parsi_tstackh);
 //     printf ( "parsi_tstacki = %d\n", parsi_tstacki);
@@ -1259,7 +1265,7 @@ void read_parsi_options_from_file (char *filename)
         no_dangling_ends = 1;
     else
         no_dangling_ends = 0;
-                                  
+
 }
 
 

--- a/simfold/src/simfold/s_min_folding.cpp
+++ b/simfold/src/simfold/s_min_folding.cpp
@@ -350,12 +350,22 @@ void s_min_folding::backtrack (seq_interval *cur_interval)
             for (k = i+TURN+1; k <= j-TURN-2; k++)
             {
                 tmp = VM->get_energy_WM (i+1,k) + VM->get_energy_WM (k+1, j-1);
+
+                if (DANGLE_MODE == 2) {
+                    tmp +=
+                        dangle_top [int_sequence [i]][int_sequence [j]][int_sequence [i+1]]
+                        + dangle_bot [int_sequence[i]][int_sequence[j]][int_sequence[j-1]];
+                }
+
                 if (tmp < min)
                 {
                     min = tmp;
                     best_k = k;
                     best_row = 1;
                 }
+
+                if (DANGLE_MODE != 1) continue;
+
                 tmp = VM->get_energy_WM (i+2,k) + VM->get_energy_WM (k+1, j-1) + 
 						dangle_top [int_sequence[i]][int_sequence[j]][int_sequence[i+1]] + 
                         misc.multi_free_base_penalty;
@@ -449,6 +459,16 @@ void s_min_folding::backtrack (seq_interval *cur_interval)
             if (energy_ij < INF)
             {
                 tmp = energy_ij + AU_penalty (int_sequence[i],int_sequence[j]) + acc;
+
+                if (DANGLE_MODE == 2) {
+                    if ( j<nb_nucleotides) {
+                        tmp += dangle_top [sequence [j]][sequence [i]][sequence [j+1]];
+                    }
+                    if ( i>0 ) {
+                        tmp += dangle_bot [sequence[j]][sequence[i]][sequence[i-1]];
+                    }
+                }
+
                 if (tmp < min)
                 {
                     min = tmp;
@@ -456,6 +476,9 @@ void s_min_folding::backtrack (seq_interval *cur_interval)
                     best_row = 1;
                 }
             }        
+
+            if ( DANGLE_MODE !=1 ) continue;
+
             energy_ij = V->get_energy(i+1,j);            
             if (energy_ij < INF)
             {
@@ -559,12 +582,24 @@ void s_min_folding::backtrack (seq_interval *cur_interval)
         tmp = V->get_energy(i,j) +
             AU_penalty (int_sequence[i], int_sequence[j]) +
             misc.multi_helix_penalty;
+
+        if (DANGLE_MODE == 2) {
+            if ( j<nb_nucleotides) {
+                tmp += dangle_top [sequence [j]][sequence [i]][sequence [j+1]];
+            }
+            if ( i>0 ) {
+                tmp += dangle_bot [sequence[j]][sequence[i]][sequence[i-1]];
+            }
+        }
+
         if (tmp < min)
         {
             min = tmp;
             best_row = 1;
         }
     
+        if ( DANGLE_MODE == 1) {
+
         tmp = V->get_energy(i+1,j) +
                 AU_penalty (int_sequence[i+1], int_sequence[j]) +
                 dangle_bot [int_sequence[j]]
@@ -626,6 +661,8 @@ void s_min_folding::backtrack (seq_interval *cur_interval)
             best_row = 4;
         }
             
+        } // end DANGLE_MODE == 1
+
         tmp = VM->get_energy_WM (i+1,j) + misc.multi_free_base_penalty;
         // add the loss
         if (pred_pairings != NULL)


### PR DESCRIPTION
Hi @IanWark, hi @HosnaJabbari,

this branch adds support for "-d2" type handling of dangling ends. Currently this works only for Sparse_CCJ---I didn't implement this for all functions of the simfold lib, (almost) only what's used by CCJ.

Currently, the dangle mode is controlled by a DEFINE in CMakeLists.txt, which was easiest to implement---in the long run, a command line option would be more convenient, of course.

As for testing, I could reproduce the CCJ energy with ViennaRNA for the following example:
SparseCCJ GGGGCCGGGGAACCCCAAAGGGCCCAAAGGGACCCUAAGGCCCC
(((((((((....)))..(((((((...))).))))..)))))) -17.21
using 
RNAeval -P ../sparse_ccj_parameter.viennarna -d2

@IanWark, could you please have a second look at this and merge.