### PR TITLE
WIP: Recomputation for P (avoid trace arrows)

### DIFF
--- a/Sparse_CCJ/base.h
+++ b/Sparse_CCJ/base.h
@@ -6,7 +6,7 @@
 
 //! type of energy
 // Should not be a short as INF is 1600000 and is a very common value for energy.
-typedef long int energy_t;
+typedef int energy_t;
 typedef unsigned short index_t;
 
 

--- a/Sparse_CCJ/candidate_list.cpp
+++ b/Sparse_CCJ/candidate_list.cpp
@@ -120,13 +120,13 @@ void candidate_list::print_CL_size() const {
     print_type();
     printf("\n");
 
-    printf("Num lists: %d\n",simple_maps.size());
+    printf("Num lists: %ld\n",simple_maps.size());
     printf("Num empty lists: %d\n",empty_lists);
     printf("Num candidates: %d\n", candidates);
 
     int p_size = sizeof(simple_maps[0]); // size of a pointer
     int empty_space = empty_lists*p_size;
-    printf("List space: %d, Empty list space: %d \n",simple_maps.size()*p_size, empty_space);
+    printf("List space: %ld, Empty list space: %d \n",simple_maps.size()*p_size, empty_space);
 
     int c_size = sizeof(candidate);
     printf("Total candidate space: %d\n", candidates*c_size );

--- a/Sparse_CCJ/candidate_list.cpp
+++ b/Sparse_CCJ/candidate_list.cpp
@@ -6,7 +6,7 @@
  */
 void candidate_list::print_type() const {
     switch (type_) {
-        case P_PLmloop:
+        case P_PLmloop0:
             printf("PLmloop_CL");
             break;
 
@@ -14,7 +14,7 @@ void candidate_list::print_type() const {
             printf("PfromL_CL");
             break;
 
-        case P_POmloop:
+        case P_POmloop0:
             printf("POmloop_CL");
             break;
 
@@ -113,7 +113,6 @@ void candidate_list::get_CL_size(int &candidates, int &empty_lists, int &size, i
  * @brief prints information on a single candidate list
  */
 void candidate_list::print_CL_size() const {
-/*
     int candidates = 0, empty_lists = 0, size = 0, capacity = 0;
     get_CL_size(candidates, empty_lists, size, capacity);
 
@@ -133,7 +132,4 @@ void candidate_list::print_CL_size() const {
     printf("Total candidate space: %d\n", candidates*c_size );
 
     printf("Size: %d, Capacity: %d\n", size, capacity);
-*/
-
 }
-

--- a/Sparse_CCJ/candidate_list.h
+++ b/Sparse_CCJ/candidate_list.h
@@ -19,66 +19,19 @@ private:
     /// TODO ordering this stuff for space
     energy_t w_;
 
-    //const candidate_PK *next = nullptr;
-
-    //void set_next(const candidate_PK *next_tgt) {
-    //    if (next_tgt != NULL) {
-    //        next= next_tgt;
-    //    }
-    //}
-
 public:
     candidate_PK(size_t set_d, size_t set_j, size_t set_k, energy_t set_w)
     : d_(set_d), j_(set_j), k_(set_k), w_(set_w)
     {
-        //next = nullptr;
-        //set_next(next_tgt);
-
         // make sure we can fit it in a short
         assert((set_w < 32768) && (set_w < 32767));
     }
-
-    ~candidate_PK() {
-        /// TODO reenable deleting
-        /// could redo this with ors for less stuff
-        //printf("start ~candidate_PK\n");
-
-        //if (d_ != -1 && j_ != -1 && k_ != -1) {
-            //printf("before delete next d:%d j:%d k:%d\n",d_,j_,k_);
-        //    delete next;
-            //printf("after delete next\n");
-        //}
-
-        //printf("end ~candidate_PK\n");
-    }
-
-    candidate_PK(const candidate_PK &source)
-    : d_(source.d()), j_(source.j()), k_(source.k()), w_(source.w())
-    {
-    }
-
-    candidate_PK& operator=(candidate_PK source)
-    {
-        std::swap(d_, source.d_);
-        std::swap(j_, source.j_);
-        std::swap(k_, source.k_);
-        std::swap(w_, source.w_);
-
-        return *this;
-    }
-
-   // const candidate_PK *get_next() const {
-        ///// TODO
-       // if (next != NULL)
-   //         return next;
-       // else
-  //          return nullptr;
-   // }
 
     short d() const { return d_; }
     short j() const { return j_; }
     short k() const { return k_; }
     energy_t w() const { return w_; }
+
 };
 
 
@@ -272,4 +225,3 @@ public:
     void get_CL_size(int &candidates, int &empty_lists, int &size, int &capacity) const;
 
 };
-

--- a/Sparse_CCJ/candidate_list.h
+++ b/Sparse_CCJ/candidate_list.h
@@ -17,10 +17,10 @@ private:
     index_t k_;
 
     /// TODO ordering this stuff for space
-    energy_t w_;
+    int w_;
 
 public:
-    candidate_PK(size_t set_d, size_t set_j, size_t set_k, energy_t set_w)
+    candidate_PK(size_t set_d, size_t set_j, size_t set_k, int set_w)
     : d_(set_d), j_(set_j), k_(set_k), w_(set_w)
     {
         // make sure we can fit it in a short
@@ -30,7 +30,7 @@ public:
     short d() const { return d_; }
     short j() const { return j_; }
     short k() const { return k_; }
-    energy_t w() const { return w_; }
+    int w() const { return w_; }
 
 };
 
@@ -48,7 +48,7 @@ public:
 
     /// TODO short or size_t or what?
     index_t d;
-    energy_t w;    // Energy
+    int w;    // Energy
 
     // should only be used by candidate_list::compactify
     candidate() {

--- a/Sparse_CCJ/h_common.h
+++ b/Sparse_CCJ/h_common.h
@@ -4,6 +4,8 @@
 #include "h_struct.h"
 #include "common.h"
 
+using matrix_type_t = char;
+
 #define P_P				'p'
 #define P_PK			'k'
 #define P_PL			'l'

--- a/Sparse_CCJ/index4D.h
+++ b/Sparse_CCJ/index4D.h
@@ -1,0 +1,109 @@
+#ifndef INDEX4D_H
+#define INDEX4D_H
+
+#include <tuple>
+
+
+//! @brief Four-dimensional index for the gap matrices
+class Index4D : public std::tuple<int,int,int,int> {
+ public:
+    Index4D(int i, int j, int k, int l)
+     :std::tuple<int,int,int,int>{i,j,k,l} {}
+
+    int i() const { return std::get<0>(*this); }
+    int j() const { return std::get<1>(*this); }
+    int k() const { return std::get<2>(*this); }
+    int l() const { return std::get<3>(*this); }
+
+    //! @brief set left and right indices for type
+    void
+    set(int d, int dp, int type) {
+        switch(type) {
+        case P_PL: i()=d;j()=dp;break;
+        case P_PM: j()=d;k()=dp;break;
+        case P_PR: k()=d;l()=dp;break;
+        case P_PO: i()=d;l()=dp;break;
+        default: assert(false);
+        }
+    }
+
+    //! @brief difference between left and right index corresponding to type
+    int
+    difference(matrix_type_t type) const {
+        switch(type) {
+        case P_PL: return j()-i();
+        case P_PM: return k()-j();
+        case P_PR: return l()-k();
+        case P_PO: return l()-i();
+        }
+    }
+
+    void
+    add(int d, int dp, int type) {
+        switch(type) {
+        case P_PL: i()+=d;j()+=dp;break;
+        case P_PM: j()+=d;k()+=dp;break;
+        case P_PR: k()+=d;l()+=dp;break;
+        case P_PO: i()+=d;l()+=dp;break;
+        default: assert(false);
+        }
+    }
+
+    //!@ shrink fragment at position of type
+    void
+    shrink(int d, int dp, int type) {
+        switch(type) {
+        case P_PL: i()+=d;j()-=dp;break;
+        case P_PM: j()-=d;k()+=dp;break;
+        case P_PR: k()+=d;l()-=dp;break;
+        case P_PO: i()+=d;l()-=dp;break;
+        default: assert(false);
+        }
+    }
+
+    Index4D &
+    operator +=(const Index4D &x);
+
+    Index4D
+    operator +(const Index4D &x) {
+        Index4D y(*this);
+        y+=x;
+        return y;
+    }
+
+    bool
+    is_valid() const {
+        return (0<=i() && i()<=j() && j()<k()-1 && k()<=l());
+    }
+
+    bool
+    is_valid(int n) const {
+        return is_valid() && l()<n;
+    }
+
+ private:
+
+    int &i() { return std::get<0>(*this); }
+    int &j() { return std::get<1>(*this); }
+    int &k() { return std::get<2>(*this); }
+    int &l() { return std::get<3>(*this); }
+};
+
+inline
+Index4D &
+Index4D::operator +=(const Index4D &x) {
+    i()+=x.i();
+    j()+=x.j();
+    k()+=x.k();
+    l()+=x.l();
+    return *this;
+}
+
+inline
+std::ostream &
+operator <<(std::ostream &out, const Index4D &x) {
+    return out<<x.i()<<" "<<x.j()<<" "<<x.k()<<" "<<x.l();
+}
+
+
+#endif // INDEX4D_H

--- a/Sparse_CCJ/matrices.h
+++ b/Sparse_CCJ/matrices.h
@@ -1,0 +1,210 @@
+#ifndef MATRICES_H
+#define MATRICES_H
+
+#include <vector>
+#include <iostream>
+
+#include "index4D.h"
+
+class TriangleMatrix {
+public:
+    TriangleMatrix() {}
+
+    void
+    init(int n, int* index)
+    {
+        n_ = n;
+        index_ = index;
+
+        int tl=total_length(n);
+        try {
+            m_.resize(tl);
+        } catch(std::exception &e) {
+            giveup (e.what(), "energy");
+        }
+        for (int i=0; i < tl; i++) m_[i] = INF+1;
+    }
+
+    int
+    ij(int i, int j) const {
+        return index_[i]+j-i;
+    }
+
+    int
+    get (int i, int j) const {
+        if (i< 0 || j<0 || i>=n_ || j>=n_){
+            return INF; // SW: this should not happen, why return INF ??
+        }
+        if (i>j)
+            return 0;
+
+        return m_[ij(i,j)];
+    }
+
+    int &
+    operator [] (int ij) {
+        return m_[ij];
+    }
+
+    int &
+    set (int i, int j) {
+        return m_[ij(i,j)];
+    }
+
+    void print() {
+        for (int i=0; i<n_; i++) {
+            std::cout << i << ": ";
+            for (int j=i; j<n_; j++) {
+                std::cout << get(i,j) << " ";
+            }
+            std::cout << std::endl;
+        }
+    }
+
+    static int
+    total_length(int n) {
+        return (n *(n+1))/2;
+    }
+
+    static int *
+    new_index(int n) {
+        int *index = new int [n];
+        index[0] = 0;
+        for (int i=1; i < n; i++) {
+            index[i] = index[i-1]+n-i+1;
+        }
+        return index;
+    }
+
+private:
+    int n_;
+    int *index_;
+    std::vector<int> m_;
+};
+
+
+//! @brief triangular matrix slices
+//! @note supports 'modulo' access for the first index i; all 3D slices for different
+//! indices i have the same size. The way of rotating the matrix could be
+//! further optimized to get space savings from j>=i!
+//! This would save significant space for the non-sparse algorithm!
+class MatrixSlices3D {
+public:
+    //! construct empty
+    MatrixSlices3D() {}
+
+    void
+    init(int n, int nb_slices=1) {
+        n_=n;
+        nb_slices_=nb_slices;
+
+        construct_index();
+        slice_size_ = offset_[n_-1][n_-1] + n_;
+        assert( slice_size_ == n_*(n_+1)*(n_+2)/6 );
+        try {
+            m_.resize(nb_slices_ * slice_size_);
+        } catch(std::exception &e) {
+            giveup (e.what(), "energy");
+        }
+        for (auto &x: m_) x=INF+1;
+    }
+
+    int get(int i, int j, int k, int l) const {
+        if (!(i <= j && j < k-1 && k <= l)){
+            //printf("!(i <= j && j < k-1 && k <= l)\n");
+            return INF;
+        }
+        // Hosna, April 3, 2014
+        // adding impossible cases
+        // Ian Wark, April 7, 2017
+        // get rid of some cases because this will have already been caught
+        // eg. if i<=j<k<=l we only need to check l>=n and i<0
+        // also made it an assert since it should never happen
+        assert(!(i<0 || l>= n_));
+
+        return m_[index(i,j,k,l)];
+    }
+
+    int get(const Index4D &x) const {
+        get(x.i(),x.j(),x.k(),x.l());
+    }
+
+    int& set(int i, int j, int k, int l) {
+        return m_[index(i,j,k,l)];
+    }
+
+    int& set(const Index4D &x) {
+        return set(x.i(),x.j(),x.k(),x.l());
+    }
+
+
+    //! set and take care of infinite energy
+    void
+    setI(int i, int j, int k, int l, int e) {
+        if (e >= INF/2) e=INF;
+        m_[index(i,j,k,l)] = e;
+    }
+
+    void
+    setI(const Index4D &x, int e) {
+        setI(x.i(),x.j(),x.k(),x.l(),e);
+    }
+
+
+    void
+    print_slice(int i, int max_j, int min_k, int max_l) const {
+        std::cerr << "SLICE "<<i<<"-"<<max_j<<"; "<<min_k<<"-"<<max_l<<std::endl;
+        for (int l=i+1; l<=max_l; l++) {
+            std::cerr << "l: " << l << std::endl;
+            for (int j=i; j<l; j++) {
+                std::cerr << "  " << j << ": ";
+                for (int k=j; k<l; k++) {
+                    std::cerr << get(Index4D(i,j,k,l)) <<" ";
+                }
+                std::cerr << std::endl;
+            }
+            std::cerr << std::endl;
+        }
+    }
+
+private:
+    int n_;
+    int nb_slices_;
+
+    //! size of one 3D slice
+    int slice_size_;
+
+    std::vector<std::vector<int>> offset_;
+
+    std::vector<int> m_;
+
+
+    size_t
+    index(int i, int j, int k, int l) const {
+        size_t idx = offset_[j][k] + l;
+        if (nb_slices_>1) {
+            i = i%nb_slices_;
+            idx += i * slice_size_;
+        }
+        return idx;
+    }
+
+    void construct_index() {
+        // construct for j<=k<=l (even if j<k-1)
+        offset_.resize(n_);
+
+        int idx=-n_;
+        for (int j=0; j<n_; j++) {
+            offset_[j].resize(n_);
+
+            offset_[j][j] = idx+(n_-j);
+
+            for (int k=j+1; k<n_; k++) {
+                offset_[j][k] = offset_[j][k-1] + (n_-k);
+            }
+            idx=offset_[j][n_-1];
+        }
+    }
+};
+
+#endif // MATRICES_H

--- a/Sparse_CCJ/pseudo_loop.cpp
+++ b/Sparse_CCJ/pseudo_loop.cpp
@@ -1302,7 +1302,7 @@ void pseudo_loop::compute_PfromL_sp(int i, int j, int k, int l){
 
         // Ian Wark Jan 23, 2017
         // push to candidates if better than b1
-        if (best_branch > 2 && i < j) {
+        if (best_branch > 1 && i < j) {
             if (cl_debug || pl_debug)
                 printf ("Push PfromL_CL(%d,%d,%d,12G2),(%d,%d)\n", j, k, l, i, min_energy);
             PfromL_CL->push_candidate(i, j, k, l, min_energy, best_branch);

--- a/Sparse_CCJ/pseudo_loop.cpp
+++ b/Sparse_CCJ/pseudo_loop.cpp
@@ -113,6 +113,8 @@ void pseudo_loop::allocate_space_sparse()
     PfromL_CL = new candidate_list(P_PfromL, nb_nucleotides, cl_debug);
     PfromO_CL = new candidate_list(P_PfromO, nb_nucleotides, cl_debug);
     PLmloop0_CL = new candidate_list(P_PLmloop0, nb_nucleotides, cl_debug);
+    PRmloop0_CL = new candidate_list(P_PRmloop0, nb_nucleotides, cl_debug);
+    PMmloop0_CL = new candidate_list(P_PMmloop0, nb_nucleotides, cl_debug);
     POmloop0_CL = new candidate_list(P_POmloop0, nb_nucleotides, cl_debug);
 
     // Ian Wark Jan 23, 2017
@@ -120,25 +122,18 @@ void pseudo_loop::allocate_space_sparse()
     PK_CL = new std::forward_list<candidate_PK> [nb_nucleotides];
     if (PK_CL == NULL) giveup ("Cannot allocate memory", "energy");
 
-    index = new int [nb_nucleotides];
-    int total_length = (nb_nucleotides *(nb_nucleotides+1))/2;
-    index[0] = 0;
-    for (int i=1; i < nb_nucleotides; i++) {
-        index[i] = index[i-1]+nb_nucleotides-i+1;
-    }
+    int total_length = TriangleMatrix::total_length(nb_nucleotides);
+
+    index = TriangleMatrix::new_index(nb_nucleotides);
+
+    WBP.init(nb_nucleotides,index);
+    WPP.init(nb_nucleotides,index);
+    WB.init(nb_nucleotides,index);
+    WP.init(nb_nucleotides,index);
+
     // Ian Wark Feb 10 2017
     // pass index to trace arrows structure
     ta->set_index(index);
-
-    WBP = new int [total_length];
-    if (WBP == NULL) giveup ("Cannot allocate memory", "energy");
-    for (i=0; i < total_length; i++) WBP[i] = INF+1;
-
-
-    WPP = new int [total_length];
-    if (WPP == NULL) giveup ("Cannot allocate memory", "energy");
-    for (i=0; i < total_length; i++) WPP[i] = INF+1;
-
 
     P = new int [total_length];
     if (P == NULL) giveup ("Cannot allocate memory", "energy");
@@ -157,17 +152,17 @@ void pseudo_loop::allocate_space_sparse()
     PfromM = init_new_3Dslice();
     PfromO = init_new_3Dslices(2);
 
-    PLmloop1 = init_new_3Dslices(2);
-    PLmloop0 = init_new_3Dslice();
+    PLmloop1.init(nb_nucleotides, 2);
+    PLmloop0.init(nb_nucleotides);
 
-    PRmloop1 = init_new_3Dslice();
-    PRmloop0 = init_new_3Dslice();
+    PRmloop1.init(nb_nucleotides);
+    PRmloop0.init(nb_nucleotides);
 
-    PMmloop1 = init_new_3Dslice();
-    PMmloop0 = init_new_3Dslice();
+    PMmloop1.init(nb_nucleotides);
+    PMmloop0.init(nb_nucleotides);
 
-    POmloop1 = init_new_3Dslices(2);
-    POmloop0 = init_new_3Dslice();
+    POmloop1.init(nb_nucleotides, 2);
+    POmloop0.init(nb_nucleotides);
 
     int_sequence = new int[nb_nucleotides];
     if (int_sequence == NULL) giveup ("Cannot allocate memory", "energy");
@@ -184,22 +179,14 @@ void pseudo_loop::allocate_space_nonsparse()
     MOD_2 = nb_nucleotides;
     MOD_MAXLOOP = nb_nucleotides;
 
-    index = new int [nb_nucleotides];
-    index[0] = 0;
-    for (int i=1; i < nb_nucleotides; i++)
-        index[i] = index[i-1]+nb_nucleotides-i+1;
+    int total_length = TriangleMatrix::total_length(nb_nucleotides);
 
-    int total_length = (nb_nucleotides *(nb_nucleotides+1))/2;
+    index = TriangleMatrix::new_index(nb_nucleotides);
 
-    WBP = new int [total_length];
-    if (WBP == NULL) giveup ("Cannot allocate memory", "energy");
-    for (i=0; i < total_length; i++) WBP[i] = INF+1;
-
-
-    WPP = new int [total_length];
-    if (WPP == NULL) giveup ("Cannot allocate memory", "energy");
-    for (i=0; i < total_length; i++) WPP[i] = INF+1;
-
+    WBP.init(nb_nucleotides,index);
+    WPP.init(nb_nucleotides,index);
+    WB.init(nb_nucleotides,index);
+    WP.init(nb_nucleotides,index);
 
     P = new int [total_length];
     if (P == NULL) giveup ("Cannot allocate memory", "energy");
@@ -217,14 +204,17 @@ void pseudo_loop::allocate_space_nonsparse()
     PfromM = init_new_4Dmatrix();
     PfromO = init_new_3Dslices(nb_nucleotides);
 
-    PLmloop1 = init_new_3Dslices(nb_nucleotides);
-    PLmloop0 = init_new_4Dmatrix();
-    PRmloop1 = init_new_4Dmatrix();
-    PRmloop0 = init_new_4Dmatrix();
-    PMmloop1 = init_new_4Dmatrix();
-    PMmloop0 = init_new_4Dmatrix();
-    POmloop1 = init_new_3Dslices(nb_nucleotides);
-    POmloop0 = init_new_4Dmatrix();
+    PLmloop1.init(nb_nucleotides, nb_nucleotides);
+    PLmloop0.init(nb_nucleotides, nb_nucleotides);
+
+    PRmloop1.init(nb_nucleotides, nb_nucleotides);
+    PRmloop0.init(nb_nucleotides, nb_nucleotides);
+
+    PMmloop1.init(nb_nucleotides, nb_nucleotides);
+    PMmloop0.init(nb_nucleotides, nb_nucleotides);
+
+    POmloop1.init(nb_nucleotides, nb_nucleotides);
+    POmloop0.init(nb_nucleotides, nb_nucleotides);
 
     int_sequence = new int[nb_nucleotides];
     if (int_sequence == NULL) giveup ("Cannot allocate memory", "energy");
@@ -235,8 +225,6 @@ pseudo_loop::~pseudo_loop()
 {
     // Sparse
     if (sparsify) {
-        delete [] WPP;
-        delete [] WBP;
         delete [] P;
 
         // De-Allocate 2D arrays properly to prevent memory leak
@@ -248,16 +236,6 @@ pseudo_loop::~pseudo_loop()
 
             delete [] PfromR[i];
             delete [] PfromM[i];
-
-            delete [] PLmloop0[i];
-
-            delete [] PRmloop1[i];
-            delete [] PRmloop0[i];
-
-            delete [] PMmloop1[i];
-            delete [] PMmloop0[i];
-
-            delete [] POmloop0[i];
         }
 
         for (int i = 0; i < MAXLOOP; i++){
@@ -271,15 +249,9 @@ pseudo_loop::~pseudo_loop()
 
         for (int i =0; i< 2; ++i){
             for(int j=0; j<nb_nucleotides; j++){
-                delete [] PLmloop1[i][j];
-                delete [] POmloop1[i][j];
-
                 delete [] PfromL[i][j];
                 delete [] PfromO[i][j];
             }
-            delete [] PLmloop1[i];
-            delete [] POmloop1[i];
-
             delete [] PfromL[i];
             delete [] PfromO[i];
         }
@@ -293,18 +265,6 @@ pseudo_loop::~pseudo_loop()
         delete [] PfromR;
         delete [] PfromM;
         delete [] PfromO;
-
-        delete [] PLmloop1;
-        delete [] PLmloop0;
-
-        delete [] PRmloop1;
-        delete [] PRmloop0;
-
-        delete [] PMmloop1;
-        delete [] PMmloop0;
-
-        delete [] POmloop1;
-        delete [] POmloop0;
 
         delete [] PK_CL;
 
@@ -319,8 +279,6 @@ pseudo_loop::~pseudo_loop()
 
     } else {
         // Non-sparse
-        delete [] WPP;
-        delete [] WBP;
         delete [] P;
 
         int total_length = (nb_nucleotides *(nb_nucleotides+1))/2;
@@ -333,16 +291,6 @@ pseudo_loop::~pseudo_loop()
 
             delete [] PfromR[i];
             delete [] PfromM[i];
-
-            delete [] PLmloop0[i];
-
-            delete [] PRmloop1[i];
-            delete [] PRmloop0[i];
-
-            delete [] PMmloop1[i];
-            delete [] PMmloop0[i];
-
-            delete [] POmloop0[i];
         }
 
         for (int i =0; i< nb_nucleotides; ++i){
@@ -352,16 +300,11 @@ pseudo_loop::~pseudo_loop()
                 delete [] PfromL[i][j];
                 delete [] PfromO[i][j];
 
-                delete [] PLmloop1[i][j];
-                delete [] POmloop1[i][j];
             }
             delete [] PL[i];
             delete [] PO[i];
             delete [] PfromL[i];
             delete [] PfromO[i];
-
-            delete [] PLmloop1[i];
-            delete [] POmloop1[i];
         }
 
         delete [] PK;
@@ -373,18 +316,6 @@ pseudo_loop::~pseudo_loop()
         delete [] PfromR;
         delete [] PfromM;
         delete [] PfromO;
-
-        delete [] PLmloop0;
-        delete [] PLmloop1;
-
-        delete [] PRmloop0;
-        delete [] PRmloop1;
-
-        delete [] PMmloop0;
-        delete [] PMmloop1;
-
-        delete [] POmloop0;
-        delete [] POmloop1;
 
         delete [] index;
         delete [] int_sequence;
@@ -412,6 +343,8 @@ void pseudo_loop::compute_energies_sp(int i, int l)
     }
     compute_WBP(i,l);
     compute_WPP(i,l);
+    compute_WB(i,l);
+    compute_WP(i,l);
 
     //2) compute all energies over gapped region [i,j]U[k,l]
     for(int j = i; j<l; j++){
@@ -477,6 +410,8 @@ void pseudo_loop::compute_energies_ns(int i, int l)
     }
     compute_WBP(i,l);
     compute_WPP(i,l);
+    compute_WB(i,l);
+    compute_WP(i,l);
 
     //2) compute all energies over gapped region [i,j]U[k,l]
     for(int j = i; j<l; j++){
@@ -562,6 +497,11 @@ void pseudo_loop::compute_WBP(int i, int l){
     }
 }
 
+void pseudo_loop::compute_WB(int i, int l){
+    assert(!impossible_case(i,l));
+    WB[WB.ij(i,l)] = (MIN(beta1P*(l-i+1),get_WBP(i,l)));
+}
+
 void pseudo_loop::compute_WPP(int i, int l){
     int min_energy = INF, b1 = INF, b2=INF;
 
@@ -588,6 +528,12 @@ void pseudo_loop::compute_WPP(int i, int l){
         WPP[il] = min_energy;
     }
 }
+
+void pseudo_loop::compute_WP(int i, int l){
+    assert(!impossible_case(i,l));
+    WP[WP.ij(i,l)] = (MIN(gamma1*(l-i+1),WPP.get(i,l)));
+}
+
 
 void pseudo_loop::compute_P_sp(int i, int l){
     int min_energy = INF, temp=INF;
@@ -847,16 +793,17 @@ pseudo_loop::recompute_slice_PLmloop0(int i, int max_j, int min_k, int max_l) {
     // set candidates
     for (int l=min_k; l<=max_l; l++) {
         for (int k=l; k>=min_k; k--) {
-            int kl = index[k]+l-k;
             for (int j=i; j<=max_j; j++) {
                 const candidate *c = PLmloop0_CL->find_candidate(i,j,k,l);
                 if (c != NULL) {
-                    PLmloop0[j][kl] = c->w;
+                    PLmloop0.set(i, j, k, l) = c->w;
                 } else {
                     // decomposition cases of compute_PLmloop0_sp(i,j,k,l):
-                    int min_energy = generic_compute_PLmloop0_sp(i,j,k,l,true);
+                    int min_energy =
+                        generic_decomposition(i, j, k, l, 1 || 2, PLmloop0_CL,
+                                              WB, PLmloop0);
 
-                    PLmloop0[j][kl] = min_energy;
+                    PLmloop0.set(i, j, k, l) = min_energy;
                 }
             }
         }
@@ -867,10 +814,11 @@ void pseudo_loop::recompute_slice_PLmloop1(int i, int max_j, int min_k, int max_
     // recompute all entries
     for (int l=min_k; l<=max_l; l++) {
         for (int k=l; k>=min_k; k--) {
-            int kl = index[k]+l-k;
             for (int j=i; j<=max_j; j++) {
-                int min_energy = generic_compute_PLmloop1_sp(i,j,k,l);
-                PLmloop1[i%MOD_2][j][kl] = min_energy;
+                int min_energy =
+                    generic_decomposition(i, j, k, l, 1 || 2, PLmloop0_CL, WBP,
+                                          PLmloop0);
+                PLmloop1.set(i,j,k,l) = min_energy;
             }
         }
     }
@@ -881,16 +829,17 @@ pseudo_loop::recompute_slice_POmloop0(int i, int max_j, int min_k, int max_l) {
     // set candidates
     for (int l=min_k; l<=max_l; l++) {
         for (int k=l; k>=min_k; k--) {
-            int kl = index[k]+l-k;
             for (int j=i; j<=max_j; j++) {
                 const candidate *c = POmloop0_CL->find_candidate(i,j,k,l);
                 if (c != NULL) {
-                    POmloop0[j][kl] = c->w;
+                    POmloop0.set(i,j,k,l) = c->w;
                 } else {
                     // decomposition cases of compute_POmloop0_sp(i,j,k,l):
-                    int min_energy = generic_compute_POmloop0_sp(i,j,k,l,true);
+                    int min_energy =
+                        generic_decomposition(i, j, k, l, 1 || 8, POmloop0_CL,
+                                              WB, POmloop0);
 
-                    POmloop0[j][kl] = min_energy;
+                    POmloop0.set(i,j,k,l) = min_energy;
                 }
             }
         }
@@ -901,10 +850,11 @@ void pseudo_loop::recompute_slice_POmloop1(int i, int max_j, int min_k, int max_
     // recompute all entries
     for (int l=min_k; l<=max_l; l++) {
         for (int k=l; k>=min_k; k--) {
-            int kl = index[k]+l-k;
             for (int j=i; j<=max_j; j++) {
-                int min_energy = generic_compute_POmloop1_sp(i,j,k,l);
-                POmloop1[i%MOD_2][j][kl] = min_energy;
+                int min_energy =
+                    generic_decomposition(i, j, k, l, 1 || 8, POmloop0_CL, WBP,
+                                          POmloop0);
+                POmloop1.set(i,j,k,l) = min_energy;
             }
         }
     }
@@ -1742,154 +1692,120 @@ void pseudo_loop::compute_PfromO_ns(int i, int j, int k, int l){
 
 }
 
+
+template<class Penalty>
 int
-pseudo_loop::generic_compute_PLmloop1_sp(int i, int j, int k, int l) {
+pseudo_loop::generic_decomposition(int i, int j, int k, int l,
+                                   int decomp_cases,
+                                   candidate_list *CL,
+                                   const TriangleMatrix &w,
+                                   const MatrixSlices3D &PX,
+                                   int LMRO_ndcases,
+                                   Penalty penalty
+                                   ) {
     int min_energy = INF;
 
     best_branch_ = -1;
     best_d_ = -1;
+    decomposing_branch_ = true;
 
     int kl = index[k] + l - k;
-    // Ian Wark Jan 23 2017
-    // 12G2 using candidate list
-    for (const candidate *c = PLmloop0_CL->get_front(j, k, l); c != NULL;
-         c = c->get_next()) {
-        int temp = c->w + get_WBP(i, c->d - 1);
-        if (temp < min_energy) {
-            min_energy = temp;
-            best_branch_ = 1;
-            best_d_ = c->d;
+
+    if ( decomp_cases & 1 && CL!=nullptr ) {
+        // Ian Wark Jan 23 2017
+        // 12G2 using candidate list
+        for (const candidate *c = CL->get_front(j, k, l); c != NULL;
+             c = c->get_next()) {
+            int temp = w.get(i, c->d - 1) + c->w;
+            if (temp < min_energy) {
+                min_energy = temp;
+                best_branch_ = 1;
+                best_d_ = c->d;
+            }
         }
     }
 
-    for (int d = i; d < j; d++) {
-        int temp = get_PLmloop0(i, d, k, l) + get_WBP(d + 1, j);
-        if (temp < min_energy) {
-            min_energy = temp;
-            best_branch_ = 2;
-            best_d_ = d;
+    if ( decomp_cases & 1 && CL==nullptr ) {
+        // 12G2 w/o candidate list (non-sparse)
+        for(int d = i+1; d<=j; d++){
+            int temp = w.get(i, d - 1) + PX.get(d, j, k, l);
+            if (temp < min_energy){
+                min_energy = temp;
+                best_branch_ = 1;
+                best_d_ = d;
+            }
         }
     }
 
-    return min_energy;
-}
-
-int
-pseudo_loop::generic_compute_POmloop1_sp(int i, int j, int k, int l) {
-    int min_energy = INF;
-
-    best_branch_ = -1;
-    best_d_ = -1;
-
-    int kl = index[k] + l - k;
-    // Ian Wark Jan 23 2017
-    // 12G2 using candidate list
-    for (const candidate *c = POmloop0_CL->get_front(j, k, l); c != NULL;
-         c = c->get_next()) {
-        int temp = c->w + get_WBP(i, c->d - 1);
-        if (temp < min_energy) {
-            min_energy = temp;
-            best_branch_ = 1;
-            best_d_ = c->d;
+    if (decomp_cases & 2) {
+        // case 1G21
+        for (int d = i; d < j; d++) {
+            int temp = PX.get(i, d, k, l) + w.get(d + 1, j);
+            if (temp < min_energy) {
+                min_energy = temp;
+                best_branch_ = 2;
+                best_d_ = d;
+            }
         }
     }
 
-    for (int d = i; d < j; d++) {
-        int temp = get_POmloop0(i, j, k, d) + get_WBP(d + 1, j);
-        if (temp < min_energy) {
-            min_energy = temp;
-            best_branch_ = 2;
-            best_d_ = d;
+    if (decomp_cases & 4) {
+        // case 1G21
+        for(int d = k+1; d <= l; d++){
+            int temp = w.get(k,d-1) + PX.get(i,j,d,l);
+            if (temp < min_energy){
+                min_energy = temp;
+                best_branch_ = 3;
+                best_d_ = d;
+            }
         }
     }
 
-    return min_energy;
-}
-
-int
-pseudo_loop::generic_compute_PLmloop0_sp(int i,
-                                         int j,
-                                         int k,
-                                         int l,
-                                         bool only_decomposing) {
-    int min_energy = INF;
-
-    best_branch_ = -1;
-    best_d_ = -1;
-
-    int kl = index[k] + l - k;
-    // Ian Wark Jan 23 2017
-    // 12G2 using candidate list
-    for (const candidate *c = PLmloop0_CL->get_front(j, k, l); c != NULL;
-         c = c->get_next()) {
-        int temp = c->w + get_WB(i, c->d - 1);
-        if (temp < min_energy) {
-            min_energy = temp;
-            best_branch_ = 1;
-            best_d_ = c->d;
+    if (decomp_cases & 8) {
+        // case 1G12
+        for (int d = i; d < j; d++) {
+            int temp = PX.get(i, j, k, d) + w.get(d + 1, j);
+            if (temp < min_energy) {
+                min_energy = temp;
+                best_branch_ = 4;
+                best_d_ = d;
+            }
         }
     }
 
-    for (int d = i; d < j; d++) {
-        int temp = get_PLmloop0(i, d, k, l) + get_WB(d + 1, j);
+    if (LMRO_ndcases & 1) {
+        int temp = get_PL(i, j, k, l) + penalty(j, i);
         if (temp < min_energy) {
             min_energy = temp;
-            best_branch_ = 2;
-            best_d_ = d;
+            best_branch_ = 5;
         }
     }
 
-    if (!only_decomposing) {
-        int temp = get_PL(i, j, k, l) + beta2P(j, i);
+    if (LMRO_ndcases & 2) {
+        int temp = get_PM(i, j, k, l) + penalty(j, k);
         if (temp < min_energy) {
             min_energy = temp;
-            best_branch_ = 3;
+            best_branch_ = 6;
         }
     }
 
-    return min_energy;
-}
-
-int
-pseudo_loop::generic_compute_POmloop0_sp(int i,
-                                         int j,
-                                         int k,
-                                         int l,
-                                         bool only_decomposing) {
-    int min_energy = INF;
-
-    best_branch_ = -1;
-    best_d_ = -1;
-
-    int kl = index[k] + l - k;
-    // Ian Wark Jan 23 2017
-    // 12G2 using candidate list
-    for (const candidate *c = POmloop0_CL->get_front(j, k, l); c != NULL;
-         c = c->get_next()) {
-        int temp = c->w + get_WB(i, c->d - 1);
+    if (LMRO_ndcases & 4) {
+        int temp = get_PR(i, j, k, l) + penalty(l, k);
         if (temp < min_energy) {
             min_energy = temp;
-            best_branch_ = 1;
-            best_d_ = c->d;
+            best_branch_ = 7;
         }
     }
 
-    for (int d = i; d < j; d++) {
-        int temp = get_POmloop0(i, d, k, l) + get_WB(d + 1, j);
+    if (LMRO_ndcases & 8) {
+        int temp = get_PO(i, j, k, l) + penalty(l, i);
         if (temp < min_energy) {
             min_energy = temp;
-            best_branch_ = 2;
-            best_d_ = d;
+            best_branch_ = 8;
         }
     }
 
-    if (!only_decomposing) {
-        int temp = get_PO(i, j, k, l) + beta2P(j, i);
-        if (temp < min_energy) {
-            min_energy = temp;
-            best_branch_ = 3;
-        }
-    }
+    decomposing_branch_ = (best_branch_ < 5);
 
     return min_energy;
 }
@@ -1899,9 +1815,10 @@ void pseudo_loop::compute_PLmloop1_sp(int i, int j, int k, int l){
 
     if (impossible_case(i,j,k,l)) {return;}
 
-    int kl = index[k]+l-k;
-    int min_energy = generic_compute_PLmloop1_sp(i,j,k,l);
-    PLmloop1[i%MOD_2][j][kl] = min_energy;
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 2, PLmloop0_CL,
+                                           WBP, PLmloop0);
+
+    PLmloop1.set(i,j,k,l) = min_energy;
 
     if (pl_debug)
         printf ("PLmloop1(%d,%d,%d,%d) branch:%d energy %d\n", i, j, k,l, best_branch_, min_energy);
@@ -1912,22 +1829,19 @@ void pseudo_loop::compute_POmloop1_sp(int i, int j, int k, int l){
 
     if (impossible_case(i,j,k,l)) {return;}
 
-    int kl = index[k]+l-k;
-    int min_energy = generic_compute_POmloop1_sp(i,j,k,l);
-    POmloop1[i%MOD_2][j][kl] = min_energy;
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 8, POmloop0_CL,
+                                           WBP, POmloop0);
+    POmloop1.set(i,j,k,l) = min_energy;
 
     if (pl_debug)
         printf ("POmloop1(%d,%d,%d,%d) branch:%d energy %d\n", i, j, k,l, best_branch_, min_energy);
 }
-
 
 void pseudo_loop::compute_PLmloop1_ns(int i, int j, int k, int l){
     int min_energy = INF;
 
     if (impossible_case(i,j,k,l)) {return;}
 
-    //int ij = index[i]+j-i;
-    int kl = index[k]+l-k;
     for(int d = i+1; d <= j; d++){
         int temp = get_WBP(i,d-1) + get_PLmloop0(d,j,k,l);
         if (temp < min_energy){
@@ -1944,7 +1858,7 @@ void pseudo_loop::compute_PLmloop1_ns(int i, int j, int k, int l){
     if (min_energy < INF/2){
         if (debug)
             printf ("PLmloop1(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PLmloop1, min_energy);
-        PLmloop1[i][j][kl] = min_energy;
+        PLmloop1.set(i,j,k,l) = min_energy;
     }
 }
 
@@ -1953,8 +1867,6 @@ void pseudo_loop::compute_PLmloop0_ns(int i, int j, int k, int l){
 
     if (impossible_case(i,j,k,l)) {return;}
 
-    int ij = index[i]+j-i;
-    int kl = index[k]+l-k;
     min_energy = get_PL(i,j,k,l)+beta2P(j,i);
 
     for(int d = i; d<=j; d++){
@@ -1976,8 +1888,7 @@ void pseudo_loop::compute_PLmloop0_ns(int i, int j, int k, int l){
     if (min_energy < INF/2){
         if (pl_debug)
             printf ("PLmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PLmloop0, min_energy);
-        int ij = index[i]+j-i;
-        PLmloop0[ij][kl] = min_energy;
+        PLmloop0.set(i,j,k,l) = min_energy;
     }
 }
 
@@ -1985,18 +1896,18 @@ void pseudo_loop::compute_PLmloop0_sp(int i, int j, int k, int l){
 
     if (impossible_case(i,j,k,l)) {return;}
 
-    int min_energy = generic_compute_PLmloop0_sp(i,j,k,l);
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 2, PLmloop0_CL, WB,
+                                           PLmloop0, 1, beta2P);
 
     if (pl_debug)
         printf ("PLmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PLmloop0, min_energy);
 
-    int kl = index[k] + l - k;
-    PLmloop0[j][kl] = min_energy;
+    PLmloop0.set(i,j,k,l) = min_energy;
 
     if (min_energy < INF/2){
         // Ian Wark Jan 23 2017
         // push to candidates
-        if ( best_branch_ > 2 ){
+        if ( !decomposing_branch_ ){
             if (cl_debug || pl_debug)
                 printf ("Push PLmloop_CL(%d,%d,%d,12G2),(%d,%d)\n", j, k, l, i, min_energy);
             PLmloop0_CL->push_candidate(i, j, k, l, min_energy, best_branch_);
@@ -2011,13 +1922,14 @@ void pseudo_loop::compute_POmloop0_sp(int i, int j, int k, int l){
 
     if (impossible_case(i,j,k,l)) {return;}
 
-    int min_energy = generic_compute_POmloop0_sp(i,j,k,l);
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 8, POmloop0_CL,
+                                           WB, POmloop0,
+                                           8, beta2P);
 
     if (pl_debug)
         printf ("POmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_POmloop0, min_energy);
 
-    int kl = index[k] + l - k;
-    POmloop0[j][kl] = min_energy;
+    POmloop0.set(i,j,k,l) = min_energy;
 
     if (min_energy < INF/2){
         // Ian Wark Jan 23 2017
@@ -2058,15 +1970,12 @@ void pseudo_loop::compute_PRmloop1(int i, int j, int k, int l){
         }
     }
 
-    int kl = index[k]+l-k;
-
     // If Non-Sparse
     if (sparsify == false) {
         if (min_energy < INF/2) {
             if (pl_debug)
                 printf ("PRmloop1(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch, min_energy);
-            int ij = index[i]+j-i;
-            PRmloop1[ij][kl]=min_energy;
+            PRmloop1.set(i,j,k,l)=min_energy;
         }
         return;
     }
@@ -2074,7 +1983,7 @@ void pseudo_loop::compute_PRmloop1(int i, int j, int k, int l){
     // Sparse
     if (pl_debug)
         printf ("PRmloop1(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PRmloop1, min_energy);
-    PRmloop1[j][kl] = min_energy;
+    PRmloop1.set(i, j, k, l) = min_energy;
 
     if (min_energy < INF/2){
         switch (best_branch) {
@@ -2125,8 +2034,7 @@ void pseudo_loop::compute_PRmloop0(int i, int j, int k, int l){
         if (min_energy < INF/2) {
             if (pl_debug)
                 printf ("PRmloop0(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch, min_energy);
-            int ij = index[i]+j-i;
-            PRmloop0[ij][kl]=min_energy;
+            PRmloop0.set(i,j,k,l)=min_energy;
         }
         return;
     }
@@ -2134,7 +2042,7 @@ void pseudo_loop::compute_PRmloop0(int i, int j, int k, int l){
     // Sparse
     if (pl_debug)
         printf ("PRmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PRmloop0, min_energy);
-    PRmloop0[j][kl] = min_energy;
+    PRmloop0.set(i,j,k,l) = min_energy;
 
     if (min_energy < INF/2){
         switch (best_branch) {
@@ -2191,8 +2099,7 @@ void pseudo_loop::compute_PMmloop1(int i, int j, int k, int l){
         if (min_energy < INF/2) {
             if (pl_debug)
                 printf ("PMmloop10(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch, min_energy);
-            int ij = index[i]+j-i;
-            PMmloop1[ij][kl]=min_energy;
+            PMmloop1.set(i,j,k,l) = min_energy;
         }
         return;
     }
@@ -2200,7 +2107,7 @@ void pseudo_loop::compute_PMmloop1(int i, int j, int k, int l){
     // Sparse
     if (pl_debug)
         printf ("PMmloop1(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PMmloop1, min_energy);
-    PMmloop1[j][kl] = min_energy;
+    PMmloop1.set(i, j, k, l) = min_energy;
 
     if (min_energy < INF/2){
         // adding trace arrows
@@ -2254,8 +2161,7 @@ void pseudo_loop::compute_PMmloop0(int i, int j, int k, int l){
         if (min_energy < INF/2) {
             if (pl_debug)
                 printf ("PMmloop0(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch, min_energy);
-            int ij = index[i]+j-i;
-            PMmloop0[ij][kl]=min_energy;
+            PMmloop0.set(i, j, k, l) = min_energy;
         }
         return;
 	}
@@ -2263,7 +2169,7 @@ void pseudo_loop::compute_PMmloop0(int i, int j, int k, int l){
     // Sparse
     if (pl_debug)
         printf ("PMmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PMmloop0, min_energy);
-    PMmloop0[j][kl] = min_energy;
+    PMmloop0.set(i, j, k, l) = min_energy;
 
     if (min_energy < INF/2){
         // adding trace arrows
@@ -2308,7 +2214,7 @@ void pseudo_loop::compute_POmloop1_ns(int i, int j, int k, int l){
     if (min_energy < INF/2){
         if (debug)
             printf ("POmloop1(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_POmloop1, min_energy);
-        POmloop1[i][j][kl] = min_energy;
+        POmloop1.set(i, j, k, l) = min_energy;
     }
 }
 
@@ -2317,8 +2223,6 @@ void pseudo_loop::compute_POmloop0_ns(int i, int j, int k, int l){
 
     if (impossible_case(i,j,k,l)) {return;}
 
-    int ij = index[i]+j-i;
-    int kl = index[k]+l-k;
     min_energy = get_PO(i,j,k,l)+beta2P(l,i);
     for(int d=i+1; d<=j; d++){
         temp=get_WB(i,d-1)+get_POmloop0(d,j,k,l);
@@ -2336,45 +2240,8 @@ void pseudo_loop::compute_POmloop0_ns(int i, int j, int k, int l){
     if (min_energy < INF/2){
         if (debug)
             printf ("POmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_POmloop0, min_energy);
-        POmloop0[ij][kl] = min_energy;
+        POmloop0.set(i, j, k, l) = min_energy;
     }
-}
-
-int pseudo_loop::get_WB(int i, int j){
-    if (i< 0 || j<0 || i>=nb_nucleotides || j>=nb_nucleotides){
-        return INF;
-    }
-    if (i>j)
-        return 0;
-
-    return (MIN(beta1P*(j-i+1),get_WBP(i,j)));
-}
-
-int pseudo_loop::get_WBP(int i, int j){
-    if (i<0 || j<0 || i>=nb_nucleotides || j>=nb_nucleotides){
-        return INF;
-    }
-
-    int ij = index[i]+j-i;
-    return WBP[ij];
-
-}
-
-int pseudo_loop::get_WP(int i, int j){
-    if (i<0 || j<0 || i>=nb_nucleotides || j>=nb_nucleotides){
-        return INF;
-    }
-    if (i>j)
-        return 0;
-
-    return (MIN(gamma1*(j-i+1),get_WPP(i,j)));
-}
-
-int pseudo_loop::get_WPP(int i, int j){
-    assert(!(i>j || i< 0 || j<0 || i>=nb_nucleotides || j>=nb_nucleotides));
-
-    int ij = index[i]+j-i;
-    return WPP[ij];
 }
 
 int pseudo_loop::get_P(int i, int j){
@@ -2697,54 +2564,12 @@ int pseudo_loop::get_PLmloop(int i, int j, int k, int l){
     return min_energy;
 }
 
-int
-pseudo_loop::get_3D_helper(int ***m, int modulo, int i, int j, int k, int l) {
-    if (!(i <= j && j < k-1 && k <= l)){
-        //printf("!(i <= j && j < k-1 && k <= l)\n");
-        return INF;
-    }
-    // Hosna, April 3, 2014
-    // adding impossible cases
-    // Ian Wark, April 7, 2017
-    // get rid of some cases because this will have already been caught
-    // eg. if i<=j<k<=l we only need to check l>=nb_nucleotides and i<0
-    // also made it an assert since it should never happen
-    assert(!(i<0 || l>= nb_nucleotides));
-
-    int kl = index[k]+l-k;
-
-    return m[i%modulo][j][kl];
-}
-
-int
-pseudo_loop::get_3D_helper(int **m, int i, int j, int k, int l) {
-    if (!(i <= j && j < k-1 && k <= l)){
-        //printf("!(i <= j && j < k-1 && k <= l)\n");
-        return INF;
-    }
-    // Hosna, April 3, 2014
-    // adding impossible cases
-    // Ian Wark, April 7, 2017
-    // get rid of some cases because this will have already been caught
-    // eg. if i<=j<k<=l we only need to check l>=nb_nucleotides and i<0
-    // also made it an assert since it should never happen
-    assert(!(i<0 || l>= nb_nucleotides));
-
-    int kl = index[k]+l-k;
-
-    if (sparsify)
-        return m[j][kl];
-    // Non-sparse
-    int ij = index[i]+j-i;
-    return m[ij][kl];
-}
-
 int pseudo_loop::get_PLmloop1(int i, int j, int k, int l){
-    return get_3D_helper(PLmloop1, MOD_2, i, j, k, l);
+    return PLmloop1.get(i, j, k, l);
 }
 
 int pseudo_loop::get_PLmloop0(int i, int j, int k, int l){
-    return get_3D_helper(PLmloop0,i,j,k,l);
+    return PLmloop0.get(i, j, k, l);
 }
 
 int pseudo_loop::get_PRiloop(int i, int j, int k, int l){
@@ -2817,11 +2642,11 @@ int pseudo_loop::get_PRmloop(int i, int j, int k, int l){
 }
 
 int pseudo_loop::get_PRmloop1(int i, int j, int k, int l){
-    return get_3D_helper(PRmloop1, i, j, k, l);
+    return PRmloop1.get(i, j, k, l);
 }
 
 int pseudo_loop::get_PRmloop0(int i, int j, int k, int l){
-    return get_3D_helper(PRmloop0, i, j, k, l);
+    return PRmloop0.get(i, j, k, l);
 }
 
 int pseudo_loop::get_PMiloop(int i, int j, int k, int l){
@@ -2899,11 +2724,11 @@ int pseudo_loop::get_PMmloop(int i, int j, int k, int l){
 }
 
 int pseudo_loop::get_PMmloop1(int i, int j, int k, int l){
-    return get_3D_helper(PMmloop1, i, j, k, l);
+    return PMmloop1.get(i, j, k, l);
 }
 
 int pseudo_loop::get_PMmloop0(int i, int j, int k, int l){
-    return get_3D_helper(PMmloop0, i, j, k, l);
+    return PMmloop0.get(i, j, k, l);
 }
 
 int pseudo_loop::get_POiloop(int i, int j, int k, int l){
@@ -2974,11 +2799,11 @@ int pseudo_loop::get_POmloop(int i, int j, int k, int l){
 }
 
 int pseudo_loop::get_POmloop1(int i, int j, int k, int l){
-    return get_3D_helper(POmloop1, MOD_2, i, j, k, l);
+    return POmloop1.get(i, j, k, l);
 }
 
 int pseudo_loop::get_POmloop0(int i, int j, int k, int l){
-    return get_3D_helper(POmloop0,i,j,k,l);
+    return POmloop0.get(i, j, k, l);
 }
 
 int pseudo_loop::get_e_stP(int i, int j){
@@ -5203,8 +5028,6 @@ void pseudo_loop::back_track_sp(minimum_fold *f, seq_interval *cur_interval)
 
     int min_energy = get_P(i,l);
 
-    //std::cerr <<" i"<<i<<" l"<<l << std::endl;
-
     for (const candidate_PK c : PK_CL[l]) {
         //std::cerr <<"   d"<<c.d()<<" j"<<c.j()<<" k"<<c.k() << std::endl;
         if (c.d() < i) continue; // skip candidates outside current interval
@@ -5488,7 +5311,9 @@ void pseudo_loop::trace_PLmloop1(int i, int j, int k, int l, int e) {
 
     //determine trace case in PLmloop1
 
-    int min_energy = generic_compute_PLmloop1_sp(i,j,k,l);
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 2, PLmloop0_CL,
+                                           WBP, PLmloop0);
+
     assert ( min_energy == e );
 
     // SW - I am unsure what we need to update here
@@ -5511,7 +5336,9 @@ void pseudo_loop::trace_PLmloop1(int i, int j, int k, int l, int e) {
 void pseudo_loop::trace_PLmloop0(int i, int j, int k, int l, int e) {
     recompute_slice_PLmloop0(i,j,k,l);
 
-    int min_energy = generic_compute_PLmloop0_sp(i,j,k,l);
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 2, PLmloop0_CL,
+                                           WB, PLmloop0, 1, beta2P);
+
     assert ( min_energy == e );
 
     // SW - I am unsure what we need to update here
@@ -5527,7 +5354,7 @@ void pseudo_loop::trace_PLmloop0(int i, int j, int k, int l, int e) {
         bt_WB(best_d_ + 1, j);
         trace_continue(i, l, best_d_, k, P_PLmloop0, get_PLmloop0(i, best_d_, k, l) );
         break;
-    case 3:
+    case 5:
         trace_continue(i, l, j, k, P_PL, get_PLmloop0(i, j, k, l) );
         break;
     default: assert(false);
@@ -5550,7 +5377,10 @@ void pseudo_loop::trace_POmloop1(int i, int j, int k, int l, int e) {
 
     //determine trace case in POmloop1
 
-    int min_energy = generic_compute_POmloop1_sp(i,j,k,l);
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 8, POmloop0_CL,
+                                           WBP, POmloop0);
+
+
     assert ( min_energy == e );
 
     trace_update_f(i,j,k,l, P_POmloop1);
@@ -5561,7 +5391,7 @@ void pseudo_loop::trace_POmloop1(int i, int j, int k, int l, int e) {
         bt_WBP(i, best_d_ - 1);
         trace_continue(best_d_, l, j, k, P_POmloop0, get_POmloop0(best_d_, j, k, l) );
         break;
-    case 2:
+    case 4:
         bt_WBP(best_d_ + 1, j);
         trace_continue(i, best_d_, j, k, P_POmloop0, get_POmloop0(i, j, k, best_d_) );
         break;
@@ -5572,7 +5402,9 @@ void pseudo_loop::trace_POmloop1(int i, int j, int k, int l, int e) {
 void pseudo_loop::trace_POmloop0(int i, int j, int k, int l, int e) {
     recompute_slice_POmloop0(i,j,k,l);
 
-    int min_energy = generic_compute_POmloop0_sp(i,j,k,l);
+    int min_energy = generic_decomposition(i, j, k, l, 1 || 8, POmloop0_CL,
+                                           WB, POmloop0, 8, beta2P);
+
     assert ( min_energy == e );
 
     trace_update_f(i,j,k,l, P_POmloop0);
@@ -5583,11 +5415,11 @@ void pseudo_loop::trace_POmloop0(int i, int j, int k, int l, int e) {
         bt_WB(i, best_d_ - 1);
         trace_continue(best_d_, l, j, k, P_POmloop0, get_POmloop0(best_d_, j, k, l) );
         break;
-    case 2:
+    case 4:
         bt_WB(best_d_ + 1, j);
         trace_continue(i, best_d_, j, k, P_POmloop0, get_POmloop0(i, j, k, best_d_) );
         break;
-    case 3:
+    case 8:
         trace_continue(i, l, j, k, P_PO, get_POmloop0(i, j, k, l) );
         break;
     default: assert(false);

--- a/Sparse_CCJ/pseudo_loop.cpp
+++ b/Sparse_CCJ/pseudo_loop.cpp
@@ -916,150 +916,90 @@ pseudo_loop::generic_decomposition(int i, int j, int k, int l,
 
 
 void
-pseudo_loop::recompute_slice_PLmloop0(int i, int max_j, int min_k, int max_l) {
+pseudo_loop::generic_recompute_slice_mloop0(int i, int max_j, int min_k, int max_l,
+                                            int decomp_cases,
+                                            candidate_list *CL,
+                                            const TriangleMatrix &w,
+                                            MatrixSlices3D &PX
+                                            ) {
     // set candidates
     for (int l=min_k; l<=max_l; l++) {
         for (int k=l; k>=min_k; k--) {
             for (int j=i; j<=max_j; j++) {
-                const candidate *c = PLmloop0_CL->find_candidate(i,j,k,l);
+                const candidate *c = CL->find_candidate(i,j,k,l);
                 if (c != NULL) {
-                    PLmloop0.set(i, j, k, l) = c->w;
+                    PX.set(i, j, k, l) = c->w;
                 } else {
                     // decomposition cases of compute_PLmloop0_sp(i,j,k,l):
                     int min_energy =
-                        generic_decomposition(i, j, k, l, 1 | 2, PLmloop0_CL,
-                                              WB, PLmloop0);
+                        generic_decomposition(i, j, k, l, decomp_cases, CL,
+                                              w, PX);
 
-                    PLmloop0.set(i, j, k, l) = min_energy;
+                    PX.set(i, j, k, l) = min_energy;
                 }
             }
         }
     }
+}
+
+void
+pseudo_loop::generic_recompute_slice_mloop1(int i, int max_j, int min_k, int max_l,
+                                            int decomp_cases,
+                                            const TriangleMatrix &w,
+                                            MatrixSlices3D &PX
+                                            ) {
+    // recompute all entries
+    for (int l=min_k; l<=max_l; l++) {
+        for (int k=l; k>=min_k; k--) {
+            for (int j=i; j<=max_j; j++) {
+                int min_energy =
+                    generic_decomposition(i, j, k, l, 1 | 2, nullptr, w, PX);
+                PX.set(i,j,k,l) = min_energy;
+            }
+        }
+    }
+}
+
+void
+pseudo_loop::recompute_slice_PLmloop0(int i, int max_j, int min_k, int max_l) {
+    generic_recompute_slice_mloop0(i, max_j, min_k, max_l, 1 | 2, PLmloop0_CL,
+                                   WB, PLmloop0);
 }
 
 void pseudo_loop::recompute_slice_PLmloop1(int i, int max_j, int min_k, int max_l) {
-    // recompute all entries
-    for (int l=min_k; l<=max_l; l++) {
-        for (int k=l; k>=min_k; k--) {
-            for (int j=i; j<=max_j; j++) {
-                int min_energy =
-                    generic_decomposition(i, j, k, l, 1 | 2, PLmloop0_CL, WBP,
-                                          PLmloop0);
-                PLmloop1.set(i,j,k,l) = min_energy;
-            }
-        }
-    }
+    generic_recompute_slice_mloop1(i, max_j, min_k, max_l, 1 | 2, WBP, PLmloop0);
 }
-
 
 void
 pseudo_loop::recompute_slice_PMmloop0(int i, int max_j, int min_k, int max_l) {
-    // set candidates
-    for (int l=min_k; l<=max_l; l++) {
-        for (int k=l; k>=min_k; k--) {
-            for (int j=i; j<=max_j; j++) {
-                const candidate *c = PMmloop0_CL->find_candidate(i,j,k,l);
-                if (c != NULL) {
-                    PMmloop0.set(i, j, k, l) = c->w;
-                } else {
-                    // decomposition cases of compute_PMmloop0_sp(i,j,k,l):
-                    int min_energy =
-                        generic_decomposition(i, j, k, l, 2 | 4, PMmloop0_CL,
-                                              WB, PMmloop0);
-
-                    PMmloop0.set(i, j, k, l) = min_energy;
-                }
-            }
-        }
-    }
+    generic_recompute_slice_mloop0(i, max_j, min_k, max_l, 2 | 4, PMmloop0_CL,
+                                   WB, PMmloop0);
 }
 
 void pseudo_loop::recompute_slice_PMmloop1(int i, int max_j, int min_k, int max_l) {
-    // recompute all entries
-    for (int l=min_k; l<=max_l; l++) {
-        for (int k=l; k>=min_k; k--) {
-            for (int j=i; j<=max_j; j++) {
-                int min_energy =
-                    generic_decomposition(i, j, k, l, 2 | 4, PMmloop0_CL, WBP,
-                                          PMmloop0);
-                PMmloop1.set(i,j,k,l) = min_energy;
-            }
-        }
-    }
+    generic_recompute_slice_mloop1(i, max_j, min_k, max_l, 2 | 4, WBP, PMmloop0);
 }
 
 void
 pseudo_loop::recompute_slice_PRmloop0(int i, int max_j, int min_k, int max_l) {
-    // set candidates
-    for (int l=min_k; l<=max_l; l++) {
-        for (int k=l; k>=min_k; k--) {
-            for (int j=i; j<=max_j; j++) {
-                const candidate *c = PRmloop0_CL->find_candidate(i,j,k,l);
-                if (c != NULL) {
-                    PRmloop0.set(i, j, k, l) = c->w;
-                } else {
-                    // decomposition cases of compute_PRmloop0_sp(i,j,k,l):
-                    int min_energy =
-                        generic_decomposition(i, j, k, l, 4 | 8, PRmloop0_CL,
-                                              WB, PRmloop0);
-
-                    PRmloop0.set(i, j, k, l) = min_energy;
-                }
-            }
-        }
-    }
+    generic_recompute_slice_mloop0(i, max_j, min_k, max_l, 4 | 8, PRmloop0_CL,
+                                   WB, PRmloop0);
 }
 
 void pseudo_loop::recompute_slice_PRmloop1(int i, int max_j, int min_k, int max_l) {
-    // recompute all entries
-    for (int l=min_k; l<=max_l; l++) {
-        for (int k=l; k>=min_k; k--) {
-            for (int j=i; j<=max_j; j++) {
-                int min_energy =
-                    generic_decomposition(i, j, k, l, 4 | 8, PRmloop0_CL, WBP,
-                                          PRmloop0);
-                PRmloop1.set(i,j,k,l) = min_energy;
-            }
-        }
-    }
+    generic_recompute_slice_mloop1(i, max_j, min_k, max_l, 4 | 8, WBP, PRmloop0);
 }
-
 
 void
 pseudo_loop::recompute_slice_POmloop0(int i, int max_j, int min_k, int max_l) {
-    // set candidates
-    for (int l=min_k; l<=max_l; l++) {
-        for (int k=l; k>=min_k; k--) {
-            for (int j=i; j<=max_j; j++) {
-                const candidate *c = POmloop0_CL->find_candidate(i,j,k,l);
-                if (c != NULL) {
-                    POmloop0.set(i,j,k,l) = c->w;
-                } else {
-                    // decomposition cases of compute_POmloop0_sp(i,j,k,l):
-                    int min_energy =
-                        generic_decomposition(i, j, k, l, 1 | 8, POmloop0_CL,
-                                              WB, POmloop0);
-
-                    POmloop0.set(i,j,k,l) = min_energy;
-                }
-            }
-        }
-    }
+    generic_recompute_slice_mloop0(i, max_j, min_k, max_l, 1 | 8, POmloop0_CL,
+                                   WB, POmloop0);
 }
 
 void pseudo_loop::recompute_slice_POmloop1(int i, int max_j, int min_k, int max_l) {
-    // recompute all entries
-    for (int l=min_k; l<=max_l; l++) {
-        for (int k=l; k>=min_k; k--) {
-            for (int j=i; j<=max_j; j++) {
-                int min_energy =
-                    generic_decomposition(i, j, k, l, 1 | 8, POmloop0_CL, WBP,
-                                          POmloop0);
-                POmloop1.set(i,j,k,l) = min_energy;
-            }
-        }
-    }
+    generic_recompute_slice_mloop1(i, max_j, min_k, max_l, 1 | 8, WBP, POmloop0);
 }
+
 
 void pseudo_loop::compute_PL(int i, int j, int k, int l){
     int min_energy = INF,b1=INF,b2=INF,b3=INF;

--- a/Sparse_CCJ/pseudo_loop.cpp
+++ b/Sparse_CCJ/pseudo_loop.cpp
@@ -551,8 +551,10 @@ void pseudo_loop::compute_PK(int i, int j, int k, int l){
         // If Non-Sparse, add to array and return here
         if (pl_debug)
             printf ("PK(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch, min_energy);
-        PK.set(i,j,k,l) = min_energy;
     }
+
+    PK.setI(i, j, k, l, min_energy);
+
     if (! sparsify) {
         return;
     }
@@ -591,19 +593,27 @@ void pseudo_loop::compute_PK(int i, int j, int k, int l){
                 break;
 
             case 3:
-                ta->register_trace_arrow(i,j,k,l, i,j,k,l, min_energy, P_PK, P_PL);
+                ta->register_trace_arrow(i,j,k,l, i,j,k,l,
+                                         min_energy -gamma2(j,i)-PB_penalty,
+                                         P_PK, P_PL);
                 break;
 
             case 4:
-                ta->register_trace_arrow(i,j,k,l, i,j,k,l, min_energy, P_PK, P_PM);
+                ta->register_trace_arrow(i,j,k,l, i,j,k,l,
+                                         min_energy -gamma2(l,k)-PB_penalty,
+                                         P_PK, P_PM);
                 break;
 
             case 5:
-                ta->register_trace_arrow(i,j,k,l, i,j,k,l, min_energy, P_PK, P_PR);
+                ta->register_trace_arrow(i,j,k,l, i,j,k,l,
+                                         min_energy -gamma2(j,k)-PB_penalty,
+                                         P_PK, P_PR);
                 break;
 
             case 6:
-                ta->register_trace_arrow(i,j,k,l, i,j,k,l, min_energy, P_PK, P_PO);
+                ta->register_trace_arrow(i,j,k,l, i,j,k,l,
+                                         min_energy -gamma2(l,i)-PB_penalty,
+                                         P_PK, P_PO);
                 break;
 
             default:
@@ -614,7 +624,7 @@ void pseudo_loop::compute_PK(int i, int j, int k, int l){
         // adding candidates
         if (best_branch > 1) {
             if (pl_debug)
-                printf ("Push PK_CL(%d,1212),(%d,%d,%d,%d)\n", i, j, k, l, min_energy);
+                printf ("Push PK_CL(%d,1212),(%d,%d,%d,e%d) best_branch: %d\n", l, i, j, k, min_energy, best_branch);
             push_candidate_PK(i, j, k, l, min_energy);
         }
     }
@@ -639,7 +649,7 @@ void pseudo_loop::recompute_slice_PK(int i, int max_l) {
             if (d != i) continue;
             int j=c.j();
             int k=c.k();
-
+            assert(c.w() < INF/2);
             PK.set(i, j, k, l) = c.w();
         }
     }
@@ -647,7 +657,7 @@ void pseudo_loop::recompute_slice_PK(int i, int max_l) {
     for (int l=i+1; l<=max_l; l++) {
         for (int j=i; j<l; j++) {
             for (int k=l; k>j; k--) {
-                if (PK.get(i, j, k, l) >= INF) {
+                if (PK.get(i, j, k, l) >= INF/2) { // no init by candidate
                     int kl = index[k]+l-k;
 
                     // compute minimum over all partitioning cases
@@ -659,9 +669,8 @@ void pseudo_loop::recompute_slice_PK(int i, int max_l) {
                     for(int d=k+1; d < l; d++) {
                         min_energy = std::min(min_energy, get_PK(i,j,d,l) + get_WP(k,d-1));  //1G21
                     }
-                    if (min_energy < INF/2) {
-                        PK.set(i, j, k, l) = min_energy;
-                    }
+
+                    PK.setI(i, j, k, l, min_energy);
                 }
             }
         }
@@ -801,6 +810,7 @@ pseudo_loop::generic_recompute_slice_mloop0(int i, int max_j, int min_k, int max
             for (int j=i; j<=max_j; j++) {
                 const candidate *c = CL->find_candidate(i,j,k,l);
                 if (c != NULL) {
+                    assert(c->w < INF/2);
                     PX.set(i, j, k, l) = c->w;
                 } else {
                     // decomposition cases of compute_PLmloop0_sp(i,j,k,l):
@@ -808,7 +818,7 @@ pseudo_loop::generic_recompute_slice_mloop0(int i, int max_j, int min_k, int max
                         generic_decomposition(i, j, k, l, decomp_cases, CL, w,
                                               PX);
 
-                    PX.set(i, j, k, l) = min_energy;
+                    PX.setI(i, j, k, l, min_energy);
                 }
             }
         }
@@ -827,7 +837,7 @@ pseudo_loop::generic_recompute_slice_mloop1(int i, int max_j, int min_k, int max
             for (int j=i; j<=max_j; j++) {
                 int min_energy = generic_decomposition(i, j, k, l, decomp_cases,
                                                        nullptr, w, PX);
-                PX.set(i,j,k,l) = min_energy;
+                PX.setI(i, j, k, l, min_energy);
             }
         }
     }
@@ -877,93 +887,39 @@ int
 pseudo_loop::generic_compute_PX(int i, int j, int k, int l, int type) {
 
     int min_energy = INF, temp;
+    best_branch_=-1;
 
     if (impossible_case(i,j,k,l)) {return INF;}
 
-    if (! can_pair(int_sequence[i],int_sequence[j])) {
-        return INF;
-    }
-
     // cases Xiloop
-    best_branch_ = 1;
     switch(type) {
     case P_PL:
-        min_energy = get_PL(i+1,j-1,k,l)+get_e_stP(i,j);
-        best_d_=i+1;
-        best_dp_=j-1;
-
-        for(int d= i+1; d<MIN(j,i+MAXLOOP); d++){
-            for(int dp = j-1; dp > MAX(d+TURN,j-MAXLOOP); dp--){
-                temp = get_e_intP(i,d,dp,j) + PL.get(d,dp,k,l);
-                if(temp < min_energy){
-                    min_energy = temp;
-                    best_d_ = d;
-                    best_dp_ = dp;
-                }
-            }
-        }
+        min_energy = get_PLiloop(i, j, k, l);
         break;
     case P_PM:
-        min_energy = get_PM(i,j-1,k+1,l)+get_e_stP(j-1,k+1);
-        best_d_ = j-1;
-        best_dp_ = k+1;
-
-        for(int d= j-1; d>MAX(i,j-MAXLOOP); d--){
-            for (int dp=k+1; dp <MIN(l,k+MAXLOOP); dp++) {
-                temp = get_e_intP(d,j,k,dp) + get_PM(i,d,dp,l);
-
-                if(temp < min_energy){
-                    min_energy = temp;
-                    best_d_ = d;
-                    best_dp_ = dp;
-                }
-            }
-        }
+        min_energy = get_PMiloop(i, j, k, l);
         break;
     case P_PR:
-        min_energy = get_PR(i,j,k+1,l-1)+get_e_stP(k,l);
-        best_d_ = k+1;
-        best_dp_ = l-1;
-
-        for(int d= k+1; d<MIN(l,k+MAXLOOP); d++){
-            for(int dp=l-1; dp > MAX(d+TURN,l-MAXLOOP); dp--){
-                temp = get_e_intP(k,d,dp,l) + get_PR(i,j,d,dp);
-                if(temp < min_energy){
-                    min_energy = temp;
-                    best_d_ = d;
-                    best_dp_ = dp;
-                }
-            }
-        }
+        min_energy = get_PRiloop(i, j, k, l);
         break;
-
     case P_PO:
-        min_energy = get_PO(i+1,j,k,l-1)+get_e_stP(i,l);
-        best_d_ = i+1;
-        best_dp_ = l-1;
-
-        for(int d= i+1; d<MIN(j,i+MAXLOOP); d++){
-            for (int dp=l-1; dp >MAX(l-MAXLOOP,k); dp--) {
-                temp = get_e_intP(i,d,dp,l) + get_PO(d,j,k,dp);
-                if(temp < min_energy){
-                    min_energy = temp;
-                    best_d_ = d;
-                    best_dp_ = dp;
-                }
-            }
-
-        }
+        min_energy = get_POiloop(i, j, k, l);
         break;
+    default: assert(false);
     }
 
-    // Hosna, April 11, 2014
-    // we need to add a branch penalty for multiloop that spans a band
+    if (min_energy < INF/2) {
+        best_branch_ = 1;
+    }
+
     switch(type) {
     case P_PL: temp = get_PLmloop(i,j,k,l); break;
     case P_PM: temp = get_PMmloop(i,j,k,l); break;
     case P_PR: temp = get_PRmloop(i,j,k,l); break;
     case P_PO: temp = get_POmloop(i,j,k,l); break;
     }
+    // Hosna, April 11, 2014
+    // we need to add a branch penalty for multiloop that spans a band
     temp += bp_penalty;
     if(temp < min_energy){
         min_energy = temp;
@@ -996,22 +952,21 @@ void pseudo_loop::compute_PL(int i, int j, int k, int l) {
     int min_energy =
         generic_compute_PX(i, j, k, l, P_PL);
 
-    if (min_energy < INF / 2) {
-        return;
-    }
+    PL.setI(i, j, k, l, min_energy);
 
-    PL.set(i, j, k, l) = min_energy;
-
-    // If Non-Sparse, end here
-    if (!sparsify)
+    // If Non-Sparse or infinite energy, end here
+    if (!sparsify || min_energy>=INF/2)
         return;
 
     if (best_branch_ == 1) {
-        if (!(avoid_candidates &&
-              PLmloop0_CL->is_candidate(best_d_, best_dp_, k, l))) {
+        if (avoid_candidates &&
+              PLmloop0_CL->is_candidate(best_d_, best_dp_, k, l)) {
+            ta->PL.avoid_trace_arrow();
+        } else {
             ta->register_trace_arrow(i, j, k, l,
                                      best_d_, best_dp_, k, l,
-                                     min_energy, P_PL, P_PL);
+                                     get_PL(best_d_, best_dp_, k, l),
+                                     P_PL, P_PL);
         }
     }
 }
@@ -1020,22 +975,35 @@ void pseudo_loop::compute_PM(int i, int j, int k, int l) {
     int min_energy =
         generic_compute_PX(i, j, k, l, P_PM);
 
-    if (min_energy >= INF / 2) {
-        return;
-    }
+    PM.setI(i, j, k, l, min_energy);
 
-    PM.set(i, j, k, l) = min_energy;
-
-    // If Non-Sparse, end here
-    if (!sparsify)
+    // If Non-Sparse or infinite energy, end here
+    if (!sparsify || min_energy>=INF/2)
         return;
 
     if (best_branch_ == 1) {
-        if (!(avoid_candidates &&
-              PMmloop0_CL->is_candidate(i, best_d_, best_dp_, l))) {
+        if (avoid_candidates &&
+            PMmloop0_CL->is_candidate(i, best_d_, best_dp_, l)) {
+            ta->PM.avoid_trace_arrow();
+
+            auto *c = PMmloop0_CL->find_candidate(i, best_d_, best_dp_, l);
+            // std::cerr << "avoid PM trace arrow " << i << " " << j << " " << k
+            //           << " " << l << "; " << i << " " << best_d_ << " "
+            //           << best_dp_ << " " << l << "; " << min_energy <<"; "
+            //           << c->w + energy_offset -beta2P(best_d_,best_dp_)
+            //           << std::endl;
+
+        } else {
+            // int energy_offset=INF;
+            // if (best_d_==j-1 && best_dp_==k+1) {
+            //     energy_offset = get_e_stP(j-1,k+1);
+            // } else {
+            //     energy_offset = get_e_intP(best_d_,j,k,best_dp_);
+            // }
+
             ta->register_trace_arrow(i, j, k, l,
                                      i, best_d_, best_dp_, l,
-                                     min_energy, P_PM, P_PM);
+                                     get_PM(i, best_d_, best_dp_, l) , P_PM, P_PM);
         }
     }
 }
@@ -1044,22 +1012,21 @@ void pseudo_loop::compute_PR(int i, int j, int k, int l) {
     int min_energy =
         generic_compute_PX(i, j, k, l, P_PR);
 
-    if (min_energy >= INF / 2) {
-        return;
-    }
+    PR.setI(i, j, k, l, min_energy);
 
-    PR.set(i, j, k, l) = min_energy;
-
-    // If Non-Sparse, end here
-    if (!sparsify)
+    // If Non-Sparse or infinite energy, end here
+    if (!sparsify || min_energy>=INF/2)
         return;
 
     if (best_branch_ == 1) {
-        if (!(avoid_candidates &&
-              PRmloop0_CL->is_candidate(i, j, best_d_, best_dp_))) {
+        if (avoid_candidates &&
+              PRmloop0_CL->is_candidate(i, j, best_d_, best_dp_)) {
+            ta->PR.avoid_trace_arrow();
+        } else {
             ta->register_trace_arrow(i, j, k, l,
                                      i, j, best_d_, best_dp_,
-                                     min_energy, P_PR, P_PR);
+                                     get_PR(i, j, best_d_, best_dp_),
+                                     P_PR, P_PR);
         }
     }
 }
@@ -1068,170 +1035,336 @@ void pseudo_loop::compute_PO(int i, int j, int k, int l) {
     int min_energy =
         generic_compute_PX(i, j, k, l, P_PO);
 
-    if (min_energy >= INF / 2) {
-        return;
-    }
+    PO.setI(i, j, k, l, min_energy);
 
-    PO.set(i, j, k, l) = min_energy;
-
-    // If Non-Sparse, end here
-    if (!sparsify)
+    // If Non-Sparse or infinite energy, end here
+    if (!sparsify || min_energy>=INF/2)
         return;
 
     if (best_branch_ == 1) {
-        if (!(avoid_candidates &&
-              POmloop0_CL->is_candidate(best_d_, j, k, best_dp_))) {
+        if (avoid_candidates &&
+              POmloop0_CL->is_candidate(best_d_, j, k, best_dp_)) {
+            ta->PO.avoid_trace_arrow();
+        } else {
             ta->register_trace_arrow(i, j, k, l,
                                      best_d_, j, k, best_dp_,
-                                     min_energy, P_PO, P_PO);
+                                     get_PO(best_d_, j, k, best_dp_),
+                                     P_PO, P_PO);
         }
     }
 }
 
 void
 pseudo_loop::trace_PL(int i, int j, int k, int l, int e) {
-    int d, dp, target_energy;
+    int best_d, best_dp, target_energy;
+    char target_type = P_PL;
+    int temp;
 
-    // iloop case: is there a trace arrow?
+    trace_update_f(i,j,k,l, P_PL);
+
+    // if there is a trace arrow, take it
+    //
     const TraceArrow *arrow = ta->PL.trace_arrow_from(i,j,k,l);
     if ( arrow != nullptr ) {
         assert ( arrow->target_type()==P_PL );
-        d = arrow->i();
-        dp = arrow->j();
-        target_energy = arrow->target_energy();
-        trace_continue(d, dp, k, l, P_PL, target_energy);
+        int d  = arrow->i();
+        int dp = arrow->j();
+        trace_update_f_with_target(i,j,k,l, P_PL, P_PL);
+        trace_continue(d, dp, k, l, target_type, arrow->target_energy());
         return;
+    }
+
+    // otherwise check PLmloop0 candidates (avoided TAs)
+    // note that PLmloop0 candidates are PL type fragments
+    //
+    int min_energy = INF;
+    for(int dp = j-1; dp > j-MAXLOOP; dp--) {
+        for (const candidate *c = PLmloop0_CL->get_front(dp, k, l); c != NULL;
+             c = c->get_next()) {
+            int d = c->d;
+
+            if (d <= i || (j - dp + d - i) > MAXLOOP)
+                continue;
+
+            int te = c->w;
+
+            // the energy of candidates (from PLmloop0_CL)
+            // is shifted by the beta2P penalty against PL;
+            // thus we subtract this penalty again!
+            te -=  beta2P(dp,d);
+
+            if ( d == i+1 && dp == j-1 ) {
+                temp = te + get_e_stP(i,j);
+            } else {
+                temp = te + get_e_intP(i,d,dp,j);
+            }
+
+            if (temp < min_energy) {
+                min_energy = temp;
+                target_energy = te;
+                best_d = d;
+                best_dp = dp;
+            }
+        }
     }
 
     // mloop case
     recompute_slice_PLmloop0(i+1,j-1,k,l);
     recompute_slice_PLmloop1(i+1,j-1,k,l);
-    int min_energy = get_PLmloop(i, j, k, l);
-    char target_type=P_PLmloop1;
-    d=i;
-    dp=j;
-    target_energy = min_energy;
-
-    // from case
-    int temp = get_PfromL(i+1, j-1, k, l) + gamma2(j,i);
+    temp = get_PLmloop(i, j, k, l);
     if (temp < min_energy) {
-        target_energy = get_PfromL(i+1, j-1, k, l);
-        target_type= P_PfromL;
-        d=i+1;
-        dp=j-1;
+        min_energy = temp;
+        target_energy = temp;
+        target_type=P_PLmloop1;
+        best_d=i;
+        best_dp=j;
     }
 
-    trace_continue(d, dp, j, k, target_type, target_energy);
+    // from case
+    if (min_energy != e) {
+        // we must be in the last case -> trace to PfromX
+        // thus, we can avoid recomputation of PfromX
+        target_energy = e - gamma2(j,i);
+        target_type= P_PfromL;
+        best_d=i+1;
+        best_dp=j-1;
+    }
+
+    trace_update_f_with_target(i,j,k,l, P_PL, target_type);
+    trace_continue(best_d, best_dp, j, k, target_type, target_energy);
 }
 
 void
 pseudo_loop::trace_PM(int i, int j, int k, int l, int e) {
-    int d, dp, target_energy;
+    int best_d=-1, best_dp=-1, target_energy=INF;
+    char target_type = P_PM;
+    int temp;
 
-    // iloop case: is there a trace arrow?
+    trace_update_f(i,j,k,l, P_PM);
+
+    // terminate on singleton arc
+    if (i==j && k==l) {
+        return;
+    }
+
+    // if there is a trace arrow, then take it
+    //
     const TraceArrow *arrow = ta->PM.trace_arrow_from(i,j,k,l);
     if ( arrow != nullptr ) {
         assert ( arrow->target_type()==P_PM );
-        d = arrow->j();
-        dp = arrow->k();
-        target_energy = arrow->target_energy();
-        trace_continue(i, d, dp, l, P_PM, target_energy);
+        int d  = arrow->j();
+        int dp = arrow->k();
+        trace_update_f_with_target(i,j,k,l, P_PM, P_PM);
+        trace_continue(i, d, dp, l, target_type, arrow->target_energy());
         return;
+    }
+
+    // otherwise check PMmloop0 candidates (avoided TAs)
+    // note that PMmloop0 candidates are PM type fragments
+    //
+    int min_energy = INF;
+
+    // we must allow trace back to singleton base pair case (i==j, k==l) PM!
+    for(int d=j-1; d>=MAX(i,j-MAXLOOP+1); d--){
+        for (int dp=k+1; dp<=MIN(l,k+MAXLOOP-1); dp++) {
+            const candidate *c = PMmloop0_CL->find_candidate(i,d,dp,l);
+            if ( c != nullptr ) {
+                int te = c->w;
+
+                te -=  beta2P(d,dp);
+
+                if ( d == j-1 && dp == k+1 ) {
+                    temp = te + get_e_stP(d,dp);
+                } else {
+                    temp = get_e_intP(d,j,k,dp) + te;
+                }
+
+                if (temp < min_energy) {
+                    min_energy = temp;
+                    target_energy = te;
+                    best_d = d;
+                    best_dp = dp;
+                }
+            }
+        }
     }
 
     // mloop case
     recompute_slice_PMmloop0(i, j-1, k+1, l);
     recompute_slice_PMmloop1(i, j-1, k+1, l);
-    int min_energy = get_PMmloop(i, j, k, l);
-    char target_type=P_PMmloop1;
-    d=j;
-    dp=k;
-    target_energy = min_energy;
-
-    // from case
-    int temp = get_PfromM(i, j-1, k+1, l) + gamma2(j,k);
+    temp = get_PMmloop(i, j, k, l);
     if (temp < min_energy) {
-        d=j-1;
-        dp=k+1;
-        target_type=P_PfromM;
-        target_energy = get_PfromM(i, d, dp, l);
+        min_energy = temp;
+        target_energy = temp;
+        target_type=P_PMmloop1;
+        best_d=j;
+        best_dp=k;
     }
 
-    trace_continue(i, d, dp, l, target_type, target_energy);
+    // from case
+    if (min_energy != e) {
+        // we must be in the last case -> trace to PfromX
+        // thus, we can avoid recomputation of PfromX
+        target_energy = e - gamma2(j,k);
+        target_type= P_PfromM;
+        best_d=j-1;
+        best_dp=k+1;
+    }
+
+    trace_update_f_with_target(i, j, k, l, P_PM, target_type);
+    trace_continue(i, best_d, best_dp, l, target_type, target_energy);
 }
 
 void
 pseudo_loop::trace_PR(int i, int j, int k, int l, int e) {
-    int d, dp, target_energy;
+    int best_d, best_dp, target_energy;
+    char target_type = P_PR;
+    int temp;
 
-    // iloop case: is there a trace arrow?
+    trace_update_f(i,j,k,l, P_PR);
+
+    // if there is a trace arrow, take it
+    //
     const TraceArrow *arrow = ta->PR.trace_arrow_from(i,j,k,l);
     if ( arrow != nullptr ) {
         assert ( arrow->target_type()==P_PR );
-        d = arrow->k();
-        dp = arrow->l();
-        target_energy = arrow->target_energy();
-        trace_continue(i, j, d, dp, P_PR, target_energy);
+        int d  = arrow->k();
+        int dp = arrow->l();
+        trace_update_f_with_target(i,j,k,l, P_PR, P_PR);
+        trace_continue(i, j, d, dp, target_type, arrow->target_energy());
         return;
+    }
+
+    // otherwise check PRmloop0 candidates (avoided TAs)
+    // note that PRmloop0 candidates are PR type fragments
+    //
+    int min_energy = INF;
+
+    for(int d= k+1; d<MIN(l,k+MAXLOOP); d++){
+        for(int dp=l-1; dp > MAX(d+TURN,l-MAXLOOP); dp--){
+            const candidate *c = PRmloop0_CL->find_candidate(i,j,d,dp);
+            if ( c != nullptr ) {
+                int te = c->w;
+
+                te -=  beta2P(dp,d);
+
+                if ( d == k+1 && dp == l-1 ) {
+                    temp = te + get_e_stP(k,l);
+                } else {
+                    temp = te + get_e_intP(k,d,dp,l);
+                }
+
+                if (temp < min_energy) {
+                    min_energy = temp;
+                    target_energy = te;
+                    best_d = d;
+                    best_dp = dp;
+                }
+            }
+        }
     }
 
     // mloop case
     recompute_slice_PRmloop0(i, j, k+1, l-1);
     recompute_slice_PRmloop1(i, j, k+1, l-1);
-    int min_energy = get_PRmloop(i, j, k, l);
-    d=j;
-    dp=k;
-    char target_type=P_PRmloop1;
-    target_energy = min_energy;
-
-    // from case
-    int temp = get_PfromR(i, j, k+1, l-1) + gamma2(l,k);
+    temp = get_PRmloop(i, j, k, l);
     if (temp < min_energy) {
-        d=k+1;
-        dp=l-1;
-        target_type = P_PfromR;
-        target_energy = get_PfromR(i, j, d, dp);
+        min_energy = temp;
+        target_energy = temp;
+        target_type=P_PRmloop1;
+        best_d=j;
+        best_dp=k;
     }
 
-    trace_continue(i, j, d, dp, target_type, target_energy);
+    // from case
+    if (min_energy != e) {
+        // we must be in the last case -> trace to PfromX
+        // thus, we can avoid recomputation of PfromX
+        target_energy = e - gamma2(l,k);
+        target_type= P_PfromR;
+        best_d = k+1;
+        best_dp= l-1;
+    }
+
+    trace_update_f_with_target(i,j,k,l, P_PR, target_type);
+    trace_continue(i, j, best_d, best_dp, target_type, target_energy);
 }
 
 void
 pseudo_loop::trace_PO(int i, int j, int k, int l, int e) {
-    int d, dp, target_energy;
+    int best_d, best_dp, target_energy;
+    char target_type = P_PO;
+    int temp;
 
-    // iloop case: is there a trace arrow?
+    trace_update_f(i,j,k,l, P_PO);
+
+    // if there is a trace arrow, take it
+    //
     const TraceArrow *arrow = ta->PO.trace_arrow_from(i,j,k,l);
     if ( arrow != nullptr ) {
         assert ( arrow->target_type()==P_PO );
-        d = arrow->i();
-        dp = arrow->l();
-        target_energy = arrow->target_energy();
-        trace_continue(d, j, k, dp, P_PO, target_energy);
+        int d  = arrow->i();
+        int dp = arrow->l();
+        trace_update_f_with_target(i,j,k,l, P_PO, P_PO);
+        trace_continue(d, j, k, dp, target_type, arrow->target_energy());
         return;
     }
 
-    // mloop case
-    recompute_slice_POmloop0(i+1, j, k, l-1);
-    recompute_slice_POmloop1(i+1, j, k, l-1);
-    int min_energy = get_POmloop(i, j, k, l);
-    d=j;
-    dp=k;
-    char target_type = P_POmloop1;
-    target_energy = min_energy;
+    // otherwise check POmloop0 candidates (avoided TAs)
+    // note that POmloop0 candidates are PO type fragments
+    //
+    int min_energy = INF;
+    for(int dp = l-1; dp > l-MAXLOOP; dp--) {
+        for (const candidate *c = POmloop0_CL->get_front(j, k, dp); c != NULL;
+             c = c->get_next()) {
+            int d = c->d;
 
-    // from case
-    int temp = get_PfromO(i+1, j, k, l-1) + gamma2(l,i);
-    if (temp < min_energy) {
-        d=i+1;
-        dp=l-1;
-        target_type = P_PfromO;
-        target_energy = get_PfromO(d, j, k, dp);
+            if (d <= i || (l - dp + d - i) > MAXLOOP)
+                continue;
+
+            int te = c->w;
+            te -=  beta2P(d,dp);
+
+            if ( d == i+1 && dp == l-1 ) {
+                temp = te + get_e_stP(i,l);
+            } else {
+                temp = te + get_e_intP(i,d,dp,j);
+            }
+
+            if (temp < min_energy) {
+                min_energy = temp;
+                target_energy = te;
+                best_d = d;
+                best_dp = dp;
+            }
+        }
     }
 
-    trace_continue(i, j, d, dp, target_type, target_energy);
-}
+    // mloop case
+    recompute_slice_POmloop0(i+1,j,k,l-1);
+    recompute_slice_POmloop1(i+1,j,k,l-1);
+    temp = get_POmloop(i, j, k, l);
+    if (temp < min_energy) {
+        min_energy = temp;
+        target_energy = temp;
+        target_type=P_POmloop1;
+        best_d=i;
+        best_dp=l;
+    }
 
+    // from case
+    if (min_energy != e) {
+        // we must be in the last case -> trace to PfromX
+        // thus, we can avoid recomputation of PfromX
+        target_energy = e - gamma2(l,i);
+        target_type= P_PfromO;
+        best_d=i+1;
+        best_dp=l-1;
+    }
+
+    trace_update_f_with_target(i,j,k,l, P_PO, target_type);
+    trace_continue(best_d, best_dp, j, k, target_type, target_energy);
+}
 
 void
 pseudo_loop::compute_PfromL(int i, int j, int k, int l) {
@@ -1245,9 +1378,9 @@ pseudo_loop::compute_PfromL(int i, int j, int k, int l) {
                                            [] (int i, int j) {
                                                return gamma2(i,j) + PB_penalty;
                                            });
+    PfromL.setI(i, j, k, l, min_energy);
 
     if (min_energy < INF/2) {
-        PfromL.set(i, j, k, l) = min_energy;
         if (pl_debug)
             printf("PfromL(%d,%d,%d,%d) branch %d energy %d\n", i, j, k, l,
                    best_branch_, min_energy);
@@ -1329,8 +1462,9 @@ void pseudo_loop::compute_PfromR(int i, int j, int k, int l){
                                                return gamma2(i,j) + PB_penalty;
                                            });
 
+    PfromR.setI(i, j, k, l, min_energy);
+
     if (min_energy < INF/2) {
-        PfromR.set(i, j, k, l) = min_energy;
         if (pl_debug)
             printf ("PfromR(%d,%d,%d,%d) branch %d energy %d\n",
                     i, j, k,l,best_branch_, min_energy);
@@ -1392,8 +1526,9 @@ void pseudo_loop::compute_PfromM(int i, int j, int k, int l){
                                                return gamma2(i,j) + PB_penalty;
                                            });
 
+    PfromM.setI(i, j, k, l, min_energy);
+
     if (min_energy < INF/2) {
-        PfromM.set(i, j, k, l) = min_energy;
         if (pl_debug)
             printf ("PfromM(%d,%d,%d,%d) branch %d energy %d\n",
                     i, j, k,l,best_branch_, min_energy);
@@ -1402,7 +1537,6 @@ void pseudo_loop::compute_PfromM(int i, int j, int k, int l){
     if (!sparsify) {
         return;
     }
-
 
     //Hosna, May 2, 2014
     // I think I should block going from PM to PO as it will solve the same band from 2 sides jumping over possible internal loops
@@ -1464,8 +1598,9 @@ void pseudo_loop::compute_PfromO(int i, int j, int k, int l){
                                                return gamma2(i,j) + PB_penalty;
                                            });
 
+    PfromO.setI(i, j, k, l, min_energy);
+
     if (min_energy < INF/2) {
-        PfromM.set(i, j, k, l) = min_energy;
         if (pl_debug)
             printf ("PfromM(%d,%d,%d,%d) branch %d energy %d\n",
                     i, j, k,l,best_branch_, min_energy);
@@ -1536,8 +1671,7 @@ void pseudo_loop::compute_PLmloop1(int i, int j, int k, int l){
 
     int min_energy = generic_decomposition(i, j, k, l, CASE_L, PLmloop0_CL,
                                            WBP, PLmloop0);
-
-    PLmloop1.set(i,j,k,l) = min_energy;
+    PLmloop1.setI(i,j,k,l,min_energy);
 
     if (pl_debug)
         printf ("PLmloop1(%d,%d,%d,%d) branch:%d energy %d\n", i, j, k,l, best_branch_, min_energy);
@@ -1553,7 +1687,7 @@ void pseudo_loop::compute_PLmloop0(int i, int j, int k, int l){
     if (pl_debug)
         printf ("PLmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PLmloop0, min_energy);
 
-    PLmloop0.set(i,j,k,l) = min_energy;
+    PLmloop0.setI(i,j,k,l,min_energy);
 
     if (!sparsify) return;
 
@@ -1577,9 +1711,7 @@ void pseudo_loop::compute_PRmloop1(int i, int j, int k, int l){
     int min_energy =
         generic_decomposition(i, j, k, l, CASE_R, PRmloop0_CL, WBP, PRmloop0);
 
-    if (min_energy < INF/2) {
-        PRmloop1.set(i, j, k, l) = min_energy;
-    }
+    PRmloop1.setI(i, j, k, l, min_energy);
 
     // If Non-Sparse
     if (sparsify == false) {
@@ -1601,23 +1733,20 @@ void pseudo_loop::compute_PRmloop0(int i, int j, int k, int l){
     int min_energy = generic_decomposition(i, j, k, l, CASE_R, PRmloop0_CL, WB,
                                            PRmloop0, CASE_PR, beta2P);
 
+
+    if (min_energy < INF/2) {
+        if (pl_debug)
+            printf("PRmloop0(%d,%d,%d,%d) branch %d energy %d\n", i, j, k, l,
+                   best_branch_, min_energy);
+    }
+    PRmloop0.setI(i, j, k, l, min_energy);
+
     // If Non-Sparse
     if (sparsify == false) {
-        if (min_energy < INF/2) {
-            if (pl_debug)
-                printf ("PRmloop0(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch_, min_energy);
-            PRmloop0.set(i,j,k,l)=min_energy;
-        }
         return;
     }
 
-    // Sparse
-    if (pl_debug)
-        printf ("PRmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PRmloop0, min_energy);
-
     if (min_energy < INF/2){
-        PRmloop0.set(i,j,k,l) = min_energy;
-
         if (!decomposing_branch_) {
             PRmloop0_CL->push_candidate(i, j, k, l, min_energy, best_branch_);
         }
@@ -1630,22 +1759,11 @@ void pseudo_loop::compute_PMmloop1(int i, int j, int k, int l){
     int min_energy =
         generic_decomposition(i, j, k, l, CASE_M, PMmloop0_CL, WBP, PMmloop0);
 
-    // If Non-Sparse
-    if (sparsify == false) {
-        if (min_energy < INF/2) {
-            if (pl_debug)
-                printf ("PMmloop10(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch_, min_energy);
-            PMmloop1.set(i, j, k, l) = min_energy;
-        }
-        return;
-    }
-
-    // Sparse
-    if (pl_debug)
-        printf ("PMmloop1(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PMmloop1, min_energy);
     if (min_energy < INF/2) {
-        PMmloop1.set(i, j, k, l) = min_energy;
+        if (pl_debug)
+            printf ("PMmloop10(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch_, min_energy);
     }
+    PMmloop1.setI(i, j, k, l, min_energy);
 }
 
 void pseudo_loop::compute_PMmloop0(int i, int j, int k, int l){
@@ -1654,23 +1772,23 @@ void pseudo_loop::compute_PMmloop0(int i, int j, int k, int l){
     int min_energy = generic_decomposition(i, j, k, l, CASE_M, PMmloop0_CL, WB,
                                            PMmloop0, CASE_PM, beta2P);
 
+    if (min_energy < INF/2) {
+        if (pl_debug)
+            printf ("PMmloop0(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch_, min_energy);
+    }
+    PMmloop0.setI(i, j, k, l, min_energy);
+
     // If Non-Sparse
     if (sparsify == false) {
-        if (min_energy < INF/2) {
-            if (pl_debug)
-                printf ("PMmloop0(%d,%d,%d,%d) branch %d energy %d\n", i, j, k,l,best_branch_, min_energy);
-            PMmloop0.set(i, j, k, l) = min_energy;
-        }
         return;
     }
 
     // Sparse
-    if (pl_debug)
-        printf ("PMmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_PMmloop0, min_energy);
     if (min_energy < INF/2){
-        PMmloop0.set(i, j, k, l) = min_energy;
-
         if (!decomposing_branch_) {
+            // if (i==1 && l==13) {
+            //     std::cerr <<"PMmloop0_CL->push_candidate "<<i<<" "<< j<<" "<< k<<" "<< l<<" "<< min_energy<<" "<< best_branch_<<std::endl;
+            // }
             PMmloop0_CL->push_candidate(i, j, k, l, min_energy, best_branch_);
         }
     }
@@ -1683,10 +1801,13 @@ void pseudo_loop::compute_POmloop1(int i, int j, int k, int l){
 
     int min_energy = generic_decomposition(i, j, k, l, CASE_O, POmloop0_CL,
                                            WBP, POmloop0);
-    POmloop1.set(i,j,k,l) = min_energy;
 
-    if (pl_debug)
-        printf ("POmloop1(%d,%d,%d,%d) branch:%d energy %d\n", i, j, k,l, best_branch_, min_energy);
+    if (min_energy < INF/2) {
+        if (pl_debug)
+            printf ("POmloop1(%d,%d,%d,%d) branch:%d energy %d\n", i, j, k,l, best_branch_, min_energy);
+    }
+
+    POmloop1.setI(i, j, k, l, min_energy);
 }
 
 void pseudo_loop::compute_POmloop0(int i, int j, int k, int l){
@@ -1696,14 +1817,14 @@ void pseudo_loop::compute_POmloop0(int i, int j, int k, int l){
     int min_energy = generic_decomposition(i, j, k, l, CASE_O, POmloop0_CL, WB,
                                            POmloop0, CASE_PO, beta2P);
 
-    if (pl_debug)
-        printf ("POmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_POmloop0, min_energy);
+    POmloop0.setI(i, j, k, l, min_energy);
 
-    POmloop0.set(i,j,k,l) = min_energy;
+    if (min_energy < INF/2) {
+        if (pl_debug)
+            printf ("POmloop0(%d,%d,%d,%d) type %c energy %d\n", i, j, k,l,P_POmloop0, min_energy);
+    }
 
-    if (!sparsify) return;
-
-    if (min_energy < INF/2){
+    if (sparsify && min_energy < INF/2){
         // Ian Wark Jan 23 2017
         // push to candidates
         if ( !decomposing_branch_ ){
@@ -1747,6 +1868,7 @@ int pseudo_loop::get_PR(int i, int j, int k, int l){
 }
 
 int pseudo_loop::get_PM(int i, int j, int k, int l){
+    assert(j>=0 && k>=0 && j<nb_nucleotides && k<nb_nucleotides);
     if (!can_pair(int_sequence[j],int_sequence[k])){
         return INF;
     }
@@ -1866,32 +1988,22 @@ int pseudo_loop::get_PLiloop(int i, int j, int k, int l){
         return INF;
     }
 
-    int min_energy = get_PL(i+1,j-1,k,l)+get_e_stP(i,j);
-    int best_branch = 1;
-
-    int branch2 = INF, best_d = -1,best_dp = -1;
-    for(int d= i+1; d<MIN(j,i+MAXLOOP); d++){
-        for(int dp = j-1; dp > MAX(d+TURN,j-MAXLOOP); dp--){
-            branch2 = get_e_intP(i,d,dp,j) + get_PL(d,dp,k,l);
-            if(branch2 < min_energy){
-                min_energy = branch2;
-                best_branch = 2;
-                best_d = d;
-                best_dp = dp;
-            }
-        }
+    int min_energy=INF;
+    if ( i+TURN+2 < j ) { // SW -- is this check required?
+        min_energy = get_PL(i+1,j-1,k,l)+get_e_stP(i,j);
+        best_d_=i+1;
+        best_dp_=j-1;
     }
 
-    // Ian Wark Feb 22 2017
-    // instead of PLiloop goes from PL->PL because
-    // PLiloop is only entered from PL and only leaves through PL so we can skip
-    // the middle step and don't need to keep track of the extra trace arrow
-    if (sparsify && min_energy < INF/2 && (!ta->PL.exists_trace_arrow_from(i,j,k,l))) {
-        if (best_branch == 1)
-            ta->register_trace_arrow(i,j,k,l,i+1,j-1,k,l,min_energy,P_PL,P_PL);
-        if (best_branch == 2)
-            ta->register_trace_arrow(i,j,k,l,best_d,best_dp,k,l,min_energy,P_PL,P_PL);
-        ta->PL.inc_shortcut();
+    for(int d= i+1; d<MIN(j,i+MAXLOOP); d++){
+        for(int dp = j-1; dp > MAX(d+TURN,j-MAXLOOP); dp--){
+            int temp = get_e_intP(i,d,dp,j) + get_PL(d,dp,k,l);
+            if(temp < min_energy){
+                min_energy = temp;
+                best_d_ = d;
+                best_dp_ = dp;
+            }
+        }
     }
 
     return min_energy;
@@ -1943,31 +2055,22 @@ int pseudo_loop::get_PRiloop(int i, int j, int k, int l){
         return INF;
     }
 
-    int min_energy = get_PR(i,j,k+1,l-1)+get_e_stP(k,l);
-    int best_branch = 1;
+    int min_energy=INF;
+    if ( k+TURN+2 < l ) { // SW -- is this check required?
+        min_energy = get_PR(i,j,k+1,l-1)+get_e_stP(k,l);
+        best_d_ = k+1;
+        best_dp_ = l-1;
+    }
 
-    int branch2 = INF, best_d = -1, best_dp = -1;
     for(int d= k+1; d<MIN(l,k+MAXLOOP); d++){
         for(int dp=l-1; dp > MAX(d+TURN,l-MAXLOOP); dp--){
-            branch2 = get_e_intP(k,d,dp,l) + get_PR(i,j,d,dp);
-            if(branch2 < min_energy){
-                min_energy = branch2;
-                best_branch = 2;
-                best_d = d;
-                best_dp = dp;
+            int temp = get_e_intP(k,d,dp,l) + get_PR(i,j,d,dp);
+            if(temp < min_energy){
+                min_energy = temp;
+                best_d_ = d;
+                best_dp_ = dp;
             }
         }
-    }
-    // Ian Wark Feb 22 2017
-    // instead of PRiloop goes from PR->PR because
-    // PRiloop is only entered from PR and only leaves through PR so we can skip
-    // the middle step and don't need to keep track of the extra trace arrow
-    if (sparsify && min_energy < INF/2 && (!ta->PR.exists_trace_arrow_from(i,j,k,l))) {
-        if (best_branch == 1)
-            ta->register_trace_arrow(i,j,k,l, i,j,k+1,l-1,min_energy,P_PR,P_PR);
-        if (best_branch == 2)
-            ta->register_trace_arrow(i,j,k,l, i,j,best_d,best_dp,min_energy,P_PR,P_PR);
-        ta->PR.inc_shortcut();
     }
 
     return min_energy;
@@ -2016,37 +2119,28 @@ int pseudo_loop::get_PMiloop(int i, int j, int k, int l){
         return INF;
     }
 
-    int min_energy = get_PM(i,j-1,k+1,l)+get_e_stP(j-1,k+1);
-    int best_branch = 1;
+    int min_energy=INF;
+    if (i<j && k<l) {
+        min_energy = get_PM(i,j-1,k+1,l)+get_e_stP(j-1,k+1);
+        best_d_ = j-1;
+        best_dp_ = k+1;
+    }
 
-    int branch2 = INF,best_d = -1, best_dp = -1;
+    int temp = INF;
     for(int d= j-1; d>MAX(i,j-MAXLOOP); d--){
         for (int dp=k+1; dp <MIN(l,k+MAXLOOP); dp++) {
-            branch2 = get_e_intP(d,j,k,dp) + get_PM(i,d,dp,l);
+            temp = get_e_intP(d,j,k,dp) + get_PM(i,d,dp,l);
 
-            if(branch2 < min_energy){
-                min_energy = branch2;
-                best_branch = 2;
-                best_d = d;
-                best_dp = dp;
+            if(temp < min_energy){
+                min_energy = temp;
+                best_d_ = d;
+                best_dp_ = dp;
             }
         }
     }
 
-    // Ian Wark Feb 22 2017
-    // instead of PMiloop goes from PM->PM because
-    // PMiloop is only entered from PM and only leaves through PM so we can skip
-    // the middle step and don't need to keep track of the extra trace arrow
-    if (sparsify && min_energy < INF/2 && (!ta->PM.exists_trace_arrow_from(i,j,k,l))) {
-        if (best_branch == 1)
-            ta->register_trace_arrow(i,j,k,l,i,j-1,k+1,l,min_energy,P_PM,P_PM);
-        if (best_branch == 2)
-            ta->register_trace_arrow(i,j,k,l, i,best_d,best_dp,l,min_energy,P_PM,P_PM);
-        ta->PM.inc_shortcut();
-   }
-
     if (pl_debug)
-        printf("get_PMiloop(%d,%d,%d,%d) branch:%d d:%d dp:%d e:%d\n",i,j,k,l, best_branch, best_d, best_dp, min_energy);
+        printf("get_PMiloop(%d,%d,%d,%d) d:%d dp:%d e:%d\n",i,j,k,l, best_d_, best_dp_, min_energy);
 
     return min_energy;
 }
@@ -2094,33 +2188,24 @@ int pseudo_loop::get_POiloop(int i, int j, int k, int l){
         return INF;
     }
 
-    int min_energy = get_PO(i+1,j,k,l-1)+get_e_stP(i,l);
-    int best_branch = 1;
-    int best_f = INF, best_b = INF, best_d = INF, best_dp = INF;
+    int min_energy=INF;
+    if (i<j && k<l) {
+        min_energy = get_PO(i+1,j,k,l-1)+get_e_stP(i,l);
+        best_d_ = i+1;
+        best_dp_ = l-1;
+    }
+
     for(int d= i+1; d<MIN(j,i+MAXLOOP); d++){
         for (int dp=l-1; dp >MAX(l-MAXLOOP,k); dp--) {
-            int branch2 = get_e_intP(i,d,dp,l) + get_PO(d,j,dp,k);
+            int temp = get_e_intP(i,d,dp,l) + get_PO(d,j,k,dp);
 
-            if(branch2 < min_energy){
-                min_energy = branch2;
-                best_branch = 2;
-                best_d = d;
-                best_dp = dp;
+            if(temp < min_energy){
+                min_energy = temp;
+                best_d_ = d;
+                best_dp_ = dp;
             }
         }
 
-    }
-
-    // Ian Wark Feb 22 2017
-    // instead of POiloop goes from PO->PO because
-    // POiloop is only entered from PO and only leaves through PO so we can skip
-    // the middle step and don't need to keep track of the extra trace arrow
-    if (sparsify && min_energy < INF/2 && (!ta->PO.exists_trace_arrow_from(i,j,k,l))) {
-        if (best_branch == 1)
-            ta->register_trace_arrow(i,j,k,l,i+1,j,k,l-1,min_energy,P_PO,P_PO);
-        if (best_branch == 2)
-            ta->register_trace_arrow(i,j,k,l,best_d,j,best_dp,k,min_energy,P_PO,P_PO);
-        ta->PO.inc_shortcut();
     }
 
     return min_energy;
@@ -4375,7 +4460,6 @@ void pseudo_loop::back_track_sp(minimum_fold *f, seq_interval *cur_interval)
     int min_energy = get_P(i,l);
 
     for (const candidate_PK c : PK_CL[l]) {
-        //std::cerr <<"   d"<<c.d()<<" j"<<c.j()<<" k"<<c.k() << std::endl;
         if (c.d() < i) continue; // skip candidates outside current interval
 
         // decomposition 1212 (where 2 is candidate c)
@@ -4384,20 +4468,20 @@ void pseudo_loop::back_track_sp(minimum_fold *f, seq_interval *cur_interval)
         int e2 = c.w();
 
         if ( e1+e2 == min_energy ) {
-
-            trace_continue(i,c.d()-1,c.j()+1,c.k()-1,P_PK,e1);
-            trace_continue(c.d(),c.j(),c.k(),l,P_PK,e2);
-
-            if (node_debug || pl_debug) {
+            //if (node_debug || pl_debug) {
                 printf ("P(%d,%d): tracing PK(%d,%d,%d,%d) e:%d and PK(%d,%d,%d,%d) e:%d\n",
                         i,l,
                         i,c.d()-1,c.j()+1,c.k()-1, e1,
                         c.d(),c.j(),c.k(),l, e2);
-            }
+            //}
 
+            trace_continue(i,c.d()-1,c.j()+1,c.k()-1,P_PK,e1);
+            trace_continue(c.d(),c.j(),c.k(),l,P_PK,e2);
             return;
         }
     }
+
+    // std::cerr << std::distance(PK_CL[l].begin(),PK_CL[l].end()) << std::endl;
 
     // SW - this should never be reached
     printf("!!!!!!There's something wrong! P(%d,%d)=%d not reconstructed.\n",i,l,min_energy);   assert(false/*trace: fail from P*/);
@@ -4926,24 +5010,24 @@ void pseudo_loop::trace_continue(int i, int j, int k, int l, char srctype, energ
         case P_PfromM: src_ta = &ta->PfromM; break;
         case P_PfromO: src_ta = &ta->PfromO; break;
 
-        case P_PL: trace_PL(i,j,k,l,e); break;
-        case P_PR: trace_PR(i,j,k,l,e); break;
-        case P_PM: trace_PM(i,j,k,l,e); break;
-        case P_PO: trace_PO(i,j,k,l,e); break;
+        case P_PL: trace_PL(i,j,k,l,e); return;
+        case P_PR: trace_PR(i,j,k,l,e); return;
+        case P_PM: trace_PM(i,j,k,l,e); return;
+        case P_PO: trace_PO(i,j,k,l,e); return;
 
-        case P_PLmloop: trace_PLmloop(i,j,k,l,e); break;
-        case P_PRmloop: trace_PRmloop(i,j,k,l,e); break;
-        case P_PMmloop: trace_PMmloop(i,j,k,l,e); break;
-        case P_POmloop: trace_POmloop(i,j,k,l,e); break;
+        case P_PLmloop: trace_PLmloop(i,j,k,l,e); return;
+        case P_PRmloop: trace_PRmloop(i,j,k,l,e); return;
+        case P_PMmloop: trace_PMmloop(i,j,k,l,e); return;
+        case P_POmloop: trace_POmloop(i,j,k,l,e); return;
 
         case P_PLmloop1: trace_PLmloop1(i,j,k,l,e); return;
         case P_PLmloop0: trace_PLmloop0(i,j,k,l,e); return;
 
-        case P_PRmloop1: trace_PRmloop1(i,j,k,l,e); break;
-        case P_PRmloop0: trace_PRmloop1(i,j,k,l,e); break;
+        case P_PRmloop1: trace_PRmloop1(i,j,k,l,e); return;
+        case P_PRmloop0: trace_PRmloop1(i,j,k,l,e); return;
 
-        case P_PMmloop1: trace_PMmloop1(i,j,k,l,e); break;
-        case P_PMmloop0: trace_PMmloop1(i,j,k,l,e); break;
+        case P_PMmloop1: trace_PMmloop1(i,j,k,l,e); return;
+        case P_PMmloop0: trace_PMmloop1(i,j,k,l,e); return;
 
         case P_POmloop1: trace_POmloop1(i,j,k,l,e); return;
         case P_POmloop0: trace_POmloop0(i,j,k,l,e); return;
@@ -5019,26 +5103,26 @@ void pseudo_loop::trace_continue(int i, int j, int k, int l, char srctype, energ
                 break;
 
                 // target is PfromL
-                case P_PL: case P_PfromL:
-                    trace_candidate(i,j,k,l, srctype, P_PfromL, e, PfromL_CL);
-                    break;
+            case P_PL: case P_PfromL:
+                trace_candidate(i,j,k,l, srctype, P_PfromL, e, PfromL_CL);
+                break;
 
                 // target is PfromM
-                case P_PM: case P_PfromM:
-                    trace_candidate(i,j,k,l, srctype, P_PfromM, e, PfromM_CL);
-                    break;
+            case P_PM: case P_PfromM:
+                trace_candidate(i,j,k,l, srctype, P_PfromM, e, PfromM_CL);
+                break;
 
                 // target is PfromR
-                case P_PR: case P_PfromR:
-                    trace_candidate(i,j,k,l, srctype, P_PfromR, e, PfromR_CL);
-                    break;
+            case P_PR: case P_PfromR:
+                trace_candidate(i,j,k,l, srctype, P_PfromR, e, PfromR_CL);
+                break;
 
                 // target is PfromO
-                case P_PO: case P_PfromO:
-                    trace_candidate(i,j,k,l, srctype, P_PfromO, e, PfromO_CL);
-                    break;
+            case P_PO: case P_PfromO:
+                trace_candidate(i,j,k,l, srctype, P_PfromO, e, PfromO_CL);
+                break;
             default:
-                    break;
+                break;
             }
 
         }
@@ -5092,7 +5176,6 @@ void pseudo_loop::trace_candidate(int i, int j, int k, int l, char srctype, char
 
     const candidate *c = nullptr;
 
-    // For PL->PfromL and PO->PfromO cases
     switch(srctype) {
         case P_PL:
             assert(tgttype == P_PfromL);
@@ -5189,8 +5272,45 @@ void pseudo_loop::trace_candidate(int i, int j, int k, int l, char srctype, char
             if (node_debug || pl_debug)
                 printf("backtrack: could not find candidate PfromL\n");
             break;
-        // PfromO(i,j,k,l)->PfromO(i,j,k,new l)
-        case P_PfromO:
+        case P_PfromM:
+            for(int d=i+1; d<j; ++d) {
+                c = CL->find_candidate(i,d,k,l);
+                if (c != nullptr) {
+                    int total = c->w+get_WP(d+1,j);
+                    if (total == e) {
+                        bt_WP(d+1,j);
+                        trace_candidate_continue(i,j,k,l, c->d,d,k,l,srctype,tgttype,c);
+                        return;
+                    }
+                }
+            }
+            for(int d=k+1; d<l; ++d) {
+                c = CL->find_candidate(i,j,d,l);
+                if (c != nullptr) {
+                    int total = c->w+get_WP(k,d-1);
+                    if (total == e) {
+                        bt_WP(k,d-1);
+                        trace_candidate_continue(i,j,k,l, i,j,d,l, srctype,tgttype,c);
+                        return;
+                    }
+                }
+            }
+            if (node_debug || pl_debug)
+                printf("backtrack: could not find candidate PfromM\n");
+            break;
+
+    case P_PfromR:
+            for(int d=k+1; d<=l; ++d) {
+                c = CL->find_candidate(i,j,d,l);
+                if (c != nullptr) {
+                    int total = c->w+get_WP(k,d-1);
+                    if (total == e) {
+                        bt_WP(d+1,j);
+                        trace_candidate_continue(i,j,k,l, i,j,d,l,srctype,tgttype,c);
+                        return;
+                    }
+                }
+            }
             for(int d=k+1; d<l; ++d) {
                 c = CL->find_candidate(i,j,k,d);
                 if (c != nullptr) {
@@ -5201,9 +5321,22 @@ void pseudo_loop::trace_candidate(int i, int j, int k, int l, char srctype, char
                         return;
                     }
                 }
-            }
-            if (node_debug || pl_debug)
-                printf("backtrack: could not find candidate in PfromO\n");
+            } if (node_debug || pl_debug)
+                printf("backtrack: could not find candidate PfromR\n");
+            break;
+    case P_PfromO:
+            for(int d=k+1; d<l; ++d) {
+                c = CL->find_candidate(i,j,k,d);
+                if (c != nullptr) {
+                    int total = c->w+get_WP(d+1,l);
+                    if (total == e) {
+                        bt_WP(d+1,l);
+                        trace_candidate_continue(i,j,k,l, c->d,j,k,d,srctype,tgttype,c);
+                        return;
+                    }
+                }
+            } if (node_debug || pl_debug)
+                printf("backtrack: could not find candidate PfromR\n");
             break;
         // PLmloop0(i,j,k,l)->PLmloop0(i,new j,k,l)
         case P_PLmloop0:
@@ -5238,9 +5371,9 @@ void pseudo_loop::trace_candidate(int i, int j, int k, int l, char srctype, char
                 printf("backtrack: could not find candidate in POmloop0\n");
             break;
         default:
-            printf("ERROR: trace_candidate target type incorrect: is");
+            printf("ERROR: trace_candidate target type incorrect: is ");
             print_type(tgttype);
-            printf("but should be PfromL, PfromO, PLmloop0 or POmloop0\n");
+            printf(" but should be PfromL, PfromO, PLmloop0 or POmloop0\n");
             break;
     }
 }

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -427,6 +427,22 @@ private:
     // fill matrix slice at i, copy candidate energies, recompute non-candidates
     void recompute_slice_PK(int i, int max_l);
 
+
+    void
+    generic_recompute_slice_mloop0(int i, int max_j, int min_k, int max_l,
+                                   int decomp_cases,
+                                   candidate_list *CL,
+                                   const TriangleMatrix &w,
+                                   MatrixSlices3D &PX
+                                   );
+
+    void
+    generic_recompute_slice_mloop1(int i, int max_j, int min_k, int max_l,
+                                   int decomp_cases,
+                                   const TriangleMatrix &w,
+                                   MatrixSlices3D &PX
+                                   );
+
     // recompute a slice of PLmloop0
     // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
     void

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -203,9 +203,14 @@ private:
     candidate_list *PfromL_CL;
     candidate_list *PfromO_CL;
 
-    // SW - add candidate lists for R and M mloops
-    candidate_list *PRmloop0_CL;
+    // SW - add candidate lists for M and R mloops
     candidate_list *PMmloop0_CL;
+    candidate_list *PRmloop0_CL;
+
+    // SW - add candidate lists for fromM and fromR
+    candidate_list *PfromM_CL;
+    candidate_list *PfromR_CL;
+
 
     // This is an array of [nb_nucleotides] forward lists
     std::forward_list<candidate_PK> *PK_CL;
@@ -321,6 +326,8 @@ public:
     void compactify() {
         if (sparsify && use_compactify) {
             PfromL_CL->compactify();
+            PfromM_CL->compactify();
+            PfromR_CL->compactify();
             PfromO_CL->compactify();
             PLmloop0_CL->compactify();
             PMmloop0_CL->compactify();

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -267,7 +267,7 @@ private:
     * @param e - energy value
     * @param CL - candidate list to look through
     */
-    void trace_candidate(int i, int j, int k, int l, char srctype, char tgttype, energy_t e, candidate_list *CL);
+    void trace_candidate(int i, int j, int k, int l, char srctype, char tgttype, int e, candidate_list *CL);
     void trace_candidate_continue(int i, int j, int k, int l, int m, int n, int o, int p, char srctype, char tgttype, const candidate *c);
 
 
@@ -283,7 +283,7 @@ private:
     * @param e - energy value
     * @param CL - candidate list to look through
     */
-    void trace_candidate(int i, int j, int k, int l, char srctype, char tgttype, energy_t e, std::forward_list<candidate_PK> *CL);
+    void trace_candidate(int i, int j, int k, int l, char srctype, char tgttype, int e, std::forward_list<candidate_PK> *CL);
 
 
     // Ian Wark Feb 8, 2017
@@ -342,6 +342,28 @@ private:
 
     void allocate_space_nonsparse();
 
+    bool impossible_case(int i, int l) const;
+
+    bool impossible_case(int i, int j, int k, int l) const;
+
+    // "output" parameters for generic_compute functions
+    int best_d_;
+    int best_branch_;
+
+    //@brief generic sparse computation of best energy and best case in PLmloop1
+    //@param i fragment left end
+    //@param j pos before gap
+    //@param k pos after gap
+    //@param l fragment right end
+    //@note sets best_branch_ to the best branch of the decomposition,
+    // sets best_d_ to the best d of the decomposition
+    //@returns energy
+    int generic_compute_PLmloop1_sp(int i, int j, int k, int l);
+
+
+    int generic_compute_PLmloop0_sp(int i, int j, int k, int l,
+                                    bool only_decomposing = false);
+
     //void compute_WM(int i, int j); // in base pair maximization, there is no difference between the two
     //void compute_WMP(int i, int l);
     //void compute_WB(int i, int j); // in base pair maximization, there is no difference between the two
@@ -381,9 +403,25 @@ private:
     void compute_POmloop0_ns(int i,int j, int k, int l);
 
 
-    // recompute all PK entries i,.,.,l
+    // recompute all PK entries i,j,k,l for fixed i and all j,k,l: i<=j<k<=max_l
     // fill matrix slice at i, copy candidate energies, recompute non-candidates
-    void recompute_PK(int i, int l);
+    void recompute_slice_PK(int i, int max_l);
+
+    // recompute a slice of PLmloop0
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_PLmloop0(int i, int max_j, int min_k, int max_l);
+
+    // recompute a slice of PLmloop1
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_PLmloop1(int i, int max_j, int min_k, int max_l);
+
+
+    void trace_PLmloop(int i, int j, int k, int l, int e);
+    void trace_PLmloop1(int i, int j, int k, int l, int e);
+    void trace_PLmloop0(int i, int j, int k, int l, int e);
+
 
     // I have to calculate the e_stP in a separate function
     int get_e_stP(int i, int j);
@@ -393,7 +431,7 @@ private:
     * @param location of source
     * @param source type
     */
-    void trace_continue(int i, int j, int k, int l, char srctype, energy_t e);
+    void trace_continue(int i, int j, int k, int l, char srctype, int e);
 
     void trace_update_f(int i, int j, int k, int l, char srctype);
     void trace_update_f_with_target(int i, int j, int k, int l, char srctype, char tgttype);

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -87,6 +87,10 @@ public:
     int
     get_3D_helper(int ***m, int modulo, int i, int j, int k, int l);
 
+    // the methods get_P?iloop return the best energy of the iloop case
+    // and set best_d_ and best_dp_ to the inner base pair ends
+    // on success (i.e. if returned energy <INF/2)
+
     int get_PLiloop(int i,int j, int k, int l);
     //int get_PLiloop5(int i,int j, int k, int l,int s);
     int get_PLmloop(int i,int j, int k, int l);

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -176,10 +176,10 @@ private:
     int ***PO;				// MFE of a TGB structure s.t. i.l is paired
 
     // transition recurrences
-    int ***PfromL;
-    int **PfromR;
-    int **PfromM;
-    int ***PfromO;
+    MatrixSlices3D PfromL;
+    MatrixSlices3D PfromR;
+    MatrixSlices3D PfromM;
+    MatrixSlices3D PfromO;
 
     // internal loops and multi loops that span a band
     MatrixSlices3D PLmloop1;
@@ -370,7 +370,24 @@ private:
     int best_branch_; //!< index of best branch
     bool decomposing_branch_; //!< whether best branch is decomposing
 
+
+    // cases for the generic decomposition
+    static const int CASE_12G2 = 1<<0;
+    static const int CASE_12G1 = 1<<1;
+    static const int CASE_1G21 = 1<<2;
+    static const int CASE_1G12 = 1<<3;
+    static const int CASE_L = CASE_12G2 | CASE_12G1;
+    static const int CASE_M = CASE_12G1 | CASE_1G21;
+    static const int CASE_R = CASE_1G21 | CASE_1G12;
+    static const int CASE_O = CASE_12G2 | CASE_1G12;
+    static const int CASE_PL = 1<<4;
+    static const int CASE_PM = 1<<5;
+    static const int CASE_PR = 1<<6;
+    static const int CASE_PO = 1<<7;
+
+    //! @brief dummy penalty function (constant 0)
     static int zero(int i, int j) {return 0;}
+
     /**
      * @brief generic computation of gap matrix "multiloop" decompositions
      * @param decomp_cases decomposition cases (bit-encoded: 1=12G2, 2=12G1, 4=1G21, 8=1G12)
@@ -382,9 +399,7 @@ private:
      * @returns minimum energy
      *
      * @note sets the variables best_d_, best_branch_, and flag
-     * decomposing_branch_.  best_branch_ encodes the cases as
-     * follows: 1=outer-left (12G2), 2=inner-left (12G1), 3=inner-right (1G21),
-     * 4=outer-right (1G12), 5=PL (1), 6=PM (1), 7=PR (1), 8=PO (1)
+     * decomposing_branch_.
      */
     template<class Penalty=int(*)(int,int)>
     int
@@ -411,12 +426,10 @@ private:
     void compute_PM(int i,int j, int k, int l);
     void compute_PO(int i,int j, int k, int l);
 
-    void compute_PfromL_sp(int i, int j, int k, int l);
-    void compute_PfromL_ns(int i, int j, int k, int l);
+    void compute_PfromL(int i, int j, int k, int l);
     void compute_PfromR(int i, int j, int k, int l);
     void compute_PfromM(int i, int j, int k, int l);
-    void compute_PfromO_sp(int i, int j, int k, int l);
-    void compute_PfromO_ns(int i, int j, int k, int l);
+    void compute_PfromO(int i, int j, int k, int l);
 
     void compute_PLmloop1(int i,int j, int k, int l);
     void compute_PLmloop0(int i,int j, int k, int l);

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -438,6 +438,27 @@ private:
     recompute_slice_PLmloop1(int i, int max_j, int min_k, int max_l);
 
 
+    // recompute a slice of PLmloop0
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_PMmloop0(int i, int max_j, int min_k, int max_l);
+
+    // recompute a slice of PLmloop1
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_PMmloop1(int i, int max_j, int min_k, int max_l);
+
+    // recompute a slice of PLmloop0
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_PRmloop0(int i, int max_j, int min_k, int max_l);
+
+    // recompute a slice of PLmloop1
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_PRmloop1(int i, int max_j, int min_k, int max_l);
+
+
     // recompute a slice of POmloop0
     // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
     void
@@ -448,10 +469,17 @@ private:
     void
     recompute_slice_POmloop1(int i, int max_j, int min_k, int max_l);
 
-
     void trace_PLmloop(int i, int j, int k, int l, int e);
     void trace_PLmloop1(int i, int j, int k, int l, int e);
     void trace_PLmloop0(int i, int j, int k, int l, int e);
+
+    void trace_PMmloop(int i, int j, int k, int l, int e);
+    void trace_PMmloop1(int i, int j, int k, int l, int e);
+    void trace_PMmloop0(int i, int j, int k, int l, int e);
+
+    void trace_PRmloop(int i, int j, int k, int l, int e);
+    void trace_PRmloop1(int i, int j, int k, int l, int e);
+    void trace_PRmloop0(int i, int j, int k, int l, int e);
 
     void trace_POmloop(int i, int j, int k, int l, int e);
     void trace_POmloop1(int i, int j, int k, int l, int e);

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -81,6 +81,9 @@ public:
     int
     get_3D_helper(int **m, int i, int j, int k, int l);
 
+    int
+    get_3D_helper(int ***m, int modulo, int i, int j, int k, int l);
+
     int get_PLiloop(int i,int j, int k, int l);
     //int get_PLiloop5(int i,int j, int k, int l,int s);
     int get_PLmloop(int i,int j, int k, int l);
@@ -364,6 +367,13 @@ private:
     int generic_compute_PLmloop0_sp(int i, int j, int k, int l,
                                     bool only_decomposing = false);
 
+    int generic_compute_POmloop1_sp(int i, int j, int k, int l);
+
+
+    int generic_compute_POmloop0_sp(int i, int j, int k, int l,
+                                    bool only_decomposing = false);
+
+
     //void compute_WM(int i, int j); // in base pair maximization, there is no difference between the two
     //void compute_WMP(int i, int l);
     //void compute_WB(int i, int j); // in base pair maximization, there is no difference between the two
@@ -418,9 +428,24 @@ private:
     recompute_slice_PLmloop1(int i, int max_j, int min_k, int max_l);
 
 
+    // recompute a slice of POmloop0
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_POmloop0(int i, int max_j, int min_k, int max_l);
+
+    // recompute a slice of POmloop1
+    // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
+    void
+    recompute_slice_POmloop1(int i, int max_j, int min_k, int max_l);
+
+
     void trace_PLmloop(int i, int j, int k, int l, int e);
     void trace_PLmloop1(int i, int j, int k, int l, int e);
     void trace_PLmloop0(int i, int j, int k, int l, int e);
+
+    void trace_POmloop(int i, int j, int k, int l, int e);
+    void trace_POmloop1(int i, int j, int k, int l, int e);
+    void trace_POmloop0(int i, int j, int k, int l, int e);
 
 
     // I have to calculate the e_stP in a separate function

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -348,7 +348,9 @@ private:
     bool impossible_case(int i, int j, int k, int l) const;
 
     // output parameters of generic_decomposition function
-    int best_d_; //!< best split point (end of the gap matrix)
+    // and recompute PL functions
+    int best_d_; //!< best split point (end of the gap matrix or first interior loop end)
+    int best_dp_; //!< best second split point (interior loop)
     int best_branch_; //!< index of best branch
     bool decomposing_branch_; //!< whether best branch is decomposing
 
@@ -392,6 +394,10 @@ private:
                           const MatrixSlices3D &PX,
                           int LMRO_cases = 0,
                           Penalty penalty = zero);
+
+    //! @brief generic computation of PL/M/R/O functions
+    int
+    generic_compute_PX(int i, int j, int k, int l, int type);
 
     //void compute_WM(int i, int j); // in base pair maximization, there is no difference between the two
     //void compute_WMP(int i, int l);
@@ -486,6 +492,11 @@ private:
     // for fix i, i<=j<=max_j min_k<=k<=l<=max_l
     void
     recompute_slice_POmloop1(int i, int max_j, int min_k, int max_l);
+
+    void trace_PL(int i, int j, int k, int l, int e);
+    void trace_PM(int i, int j, int k, int l, int e);
+    void trace_PR(int i, int j, int k, int l, int e);
+    void trace_PO(int i, int j, int k, int l, int e);
 
     void trace_PLmloop(int i, int j, int k, int l, int e);
     void trace_PLmloop1(int i, int j, int k, int l, int e);

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -168,12 +168,12 @@ private:
     TriangleMatrix WB;				// the loop inside a multiloop that spans a band // in base pair maximization, there is no difference between the two
     TriangleMatrix WBP;				// similar to WB but has at least one base pair
 
-    int *P;					// the main loop for pseudoloops and bands
-    int **PK;				// MFE of a TGB structure over gapped region [i,j] U [k,l]
-    int ***PL;				// MFE of a TGB structure s.t. i.j is paired
-    int **PR;				// MFE of a TGB structure s.t. k.l is paired
-    int **PM;				// MFE of a TGB structure s.t. j.k is paired
-    int ***PO;				// MFE of a TGB structure s.t. i.l is paired
+    TriangleMatrix P;					// the main loop for pseudoloops and bands
+    MatrixSlices3D PK;				// MFE of a TGB structure over gapped region [i,j] U [k,l]
+    MatrixSlices3D PL;				// MFE of a TGB structure s.t. i.j is paired
+    MatrixSlices3D PR;				// MFE of a TGB structure s.t. k.l is paired
+    MatrixSlices3D PM;				// MFE of a TGB structure s.t. j.k is paired
+    MatrixSlices3D PO;				// MFE of a TGB structure s.t. i.l is paired
 
     // transition recurrences
     MatrixSlices3D PfromL;
@@ -215,24 +215,6 @@ private:
     // This is an array of [nb_nucleotides] forward lists
     std::forward_list<candidate_PK> *PK_CL;
 
-
-    //! @brief allocate and initialize a 3D matrix slice
-    //! @return slice
-    int **
-    init_new_3Dslice();
-
-    //! @brief allocate and initialize an array of 3D matrix slices
-    //! @param n number of slices
-    //! @return slice
-    int ***
-    init_new_3Dslices(int n);
-
-    //! @brief allocate and initialize a 4D matrix
-    //! @return slice
-    //! @note the 4D matrix is represented as 2D matrix (product of two triangular matrices)
-    int **
-    init_new_4Dmatrix();
-
     void push_candidate_PK(int d, int j, int k, int l, int w)
     {
         PK_CL[l].push_front(candidate_PK(d,j,k,w));
@@ -266,7 +248,7 @@ private:
 
             if (c.d() == i && c.j() == j && c.k() == k) { return &c; }
         }
-        // No candidate found in CL with that i
+        // No candidate found in CL with that l
         return nullptr;
     }
 

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -196,6 +196,7 @@ private:
     candidate_list *POmloop0_CL;
     candidate_list *PfromL_CL;
     candidate_list *PfromO_CL;
+
     // This is an array of [nb_nucleotides] forward lists
     std::forward_list<candidate_PK> *PK_CL;
 
@@ -248,7 +249,7 @@ private:
             //assert(c->j() > prev_j || c->d() < prev_d || c->k() > prev_k);
             //prev_j = c->j(); prev_d = c->d(); prev_k = c->k();
 
-            if (c.j() == i && c.d() == j && c.k() == k) { return &c; }
+            if (c.d() == i && c.j() == j && c.k() == k) { return &c; }
         }
         // No candidate found in CL with that i
         return nullptr;
@@ -378,6 +379,11 @@ private:
     void compute_POmloop1_ns(int i,int j, int k, int l);
     void compute_POmloop0_sp(int i,int j, int k, int l);
     void compute_POmloop0_ns(int i,int j, int k, int l);
+
+
+    // recompute all PK entries i,.,.,l
+    // fill matrix slice at i, copy candidate energies, recompute non-candidates
+    void recompute_PK(int i, int l);
 
     // I have to calculate the e_stP in a separate function
     int get_e_stP(int i, int j);

--- a/Sparse_CCJ/pseudo_loop.h
+++ b/Sparse_CCJ/pseudo_loop.h
@@ -373,6 +373,11 @@ private:
      * @param LMRO_cases non-decomposition cases (bit-encoded: 1=L, 2=M, 4=R, 8=O)
      * @param penalty penalty function for non-decomposition cases
      * @returns minimum energy
+     *
+     * @note sets the variables best_d_, best_branch_, and flag
+     * decomposing_branch_.  best_branch_ encodes the cases as
+     * follows: 1=outer-left (12G2), 2=inner-left (12G1), 3=inner-right (1G21),
+     * 4=outer-right (1G12), 5=PL (1), 6=PM (1), 7=PR (1), 8=PO (1)
      */
     template<class Penalty=int(*)(int,int)>
     int
@@ -406,10 +411,8 @@ private:
     void compute_PfromO_sp(int i, int j, int k, int l);
     void compute_PfromO_ns(int i, int j, int k, int l);
 
-    void compute_PLmloop1_sp(int i,int j, int k, int l);
-    void compute_PLmloop1_ns(int i,int j, int k, int l);
-    void compute_PLmloop0_sp(int i,int j, int k, int l);
-    void compute_PLmloop0_ns(int i,int j, int k, int l);
+    void compute_PLmloop1(int i,int j, int k, int l);
+    void compute_PLmloop0(int i,int j, int k, int l);
 
     void compute_PRmloop1(int i,int j, int k, int l);
     void compute_PRmloop0(int i,int j, int k, int l);
@@ -417,11 +420,8 @@ private:
     void compute_PMmloop1(int i,int j, int k, int l);
     void compute_PMmloop0(int i,int j, int k, int l);
 
-    void compute_POmloop1_sp(int i,int j, int k, int l);
-    void compute_POmloop1_ns(int i,int j, int k, int l);
-    void compute_POmloop0_sp(int i,int j, int k, int l);
-    void compute_POmloop0_ns(int i,int j, int k, int l);
-
+    void compute_POmloop1(int i,int j, int k, int l);
+    void compute_POmloop0(int i,int j, int k, int l);
 
     // recompute all PK entries i,j,k,l for fixed i and all j,k,l: i<=j<k<=max_l
     // fill matrix slice at i, copy candidate energies, recompute non-candidates

--- a/Sparse_CCJ/trace_arrow.h
+++ b/Sparse_CCJ/trace_arrow.h
@@ -373,11 +373,8 @@ private:
 
 public:
     // A seperate TraceArrows for each matrix source type
-    // Unneccesarry ones such as PMiloop have been combined into others (PM in this case)
     // Explanation in comments by ta_replace in TraceArrows
     // PLiloop -> PL  PRiloop -> PR  PMiloop -> PM  POiloop -> PO
-    // PLmloop01 -> PLmloop00  POmloop01 -> POmloop00
-    TraceArrows P;
 
     TraceArrows PK;
 
@@ -390,23 +387,6 @@ public:
     TraceArrows PR;
     TraceArrows PM;
     TraceArrows PO;
-
-    TraceArrows PLmloop;
-    TraceArrows PRmloop;
-    TraceArrows PMmloop;
-    TraceArrows POmloop;
-
-    TraceArrows PLmloop1;
-    TraceArrows PLmloop0;
-
-    TraceArrows PRmloop1;
-    TraceArrows PRmloop0;
-
-    TraceArrows PMmloop1;
-    TraceArrows PMmloop0;
-
-    TraceArrows POmloop1;
-    TraceArrows POmloop0;
 
     /**
      * @brief Construct for sequence of specific length

--- a/Sparse_CCJ/trace_arrow.h
+++ b/Sparse_CCJ/trace_arrow.h
@@ -378,6 +378,7 @@ public:
     // PLiloop -> PL  PRiloop -> PR  PMiloop -> PM  POiloop -> PO
     // PLmloop01 -> PLmloop00  POmloop01 -> POmloop00
     TraceArrows P;
+
     TraceArrows PK;
 
     TraceArrows PfromL;


### PR DESCRIPTION
Hi @IanWark, hi @HosnaJabbari,

I pushed a first modification using recomputation (of the PK matrix slices during traceback) to replace trace arrows (so far, only for arrows from P to PK). The same can be done to replace most of the other trace arrows. I am going on to do this at least for the mloop matrices; then let's see what we can gain from this:)

btw: at least currently (as long as we do not use recomputation everywhere), we can trade off candidates vs. trace arrows (an interesting new idea to save more space)